### PR TITLE
COP-9029: Show and hide logic for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build and test](https://github.com/UKHomeOffice/cop-react-form-renderer/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/UKHomeOffice/cop-react-form-renderer/actions/workflows/build-and-test.yml)
+[![Publish cop-react-form-renderer to npm](https://github.com/UKHomeOffice/cop-react-form-renderer/actions/workflows/publish-cop-react-form-renderer-to-npm.yml/badge.svg)](https://github.com/UKHomeOffice/cop-react-form-renderer/actions/workflows/publish-cop-react-form-renderer-to-npm.yml)
+[![Deploy Storybook](https://github.com/UKHomeOffice/cop-react-form-renderer/actions/workflows/deploy-storybook.yml/badge.svg)](https://github.com/UKHomeOffice/cop-react-form-renderer/actions/workflows/deploy-storybook.yml)
 # Getting Started with COP React Form Renderer
 
 The COP React Form Renderer is a library that renders a form on the basis of a supplied JSON.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The COP React Form Renderer is a library that renders a form on the basis of a supplied JSON.
 
-It uses components from [https://github.com/UKHomeOffice/cop-react-design-system](COP React Design System).
+It uses components from [COP React Design System](https://github.com/UKHomeOffice/cop-react-design-system).
 - `@ukhomeoffice/cop-react-components` - and offers various styles of forms. These are showcased inside of
 a [yarn storybook](Storybook) within the project.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "scripts": {
     "clean": "rimraf dist",
-    "test": "react-scripts test --passWithNoTests",
+    "test": "react-scripts test",
     "lint": "eslint --ext .js,.jsx src",
     "storybook:start": "start-storybook --docs --no-manager-cache -p 6007",
     "storybook:build": "build-storybook --docs",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
-const Utils = {};
+import Utils from './utils';
 
-export default Utils;
+export {
+  Utils
+};

--- a/src/utils/Component/index.js
+++ b/src/utils/Component/index.js
@@ -1,4 +1,5 @@
 import showComponent from './showComponent';
+
 const Component = {
   show: showComponent,
 };

--- a/src/utils/Component/index.js
+++ b/src/utils/Component/index.js
@@ -1,0 +1,6 @@
+import showComponent from './showComponent';
+const Component = {
+  show: showComponent,
+};
+
+export default Component;

--- a/src/utils/Component/showComponent.js
+++ b/src/utils/Component/showComponent.js
@@ -1,0 +1,28 @@
+// Local imports
+import Data from '../Data';
+import meetsCondition from '../meetsCondition';
+
+const showComponent = (component, data) => {
+  if (!component) {
+    return false;
+  }
+  if (component.hidden && component.disabled) {
+    return false;
+  }
+  if (component.show_when) {
+    if (Array.isArray(component.show_when)) {
+      let allConditionsMet = true;
+      component.show_when.forEach(condition => {
+        const sourceDataValue = Data.getSource(data, condition.field);
+        allConditionsMet = allConditionsMet && meetsCondition(condition, sourceDataValue);
+      });
+      return allConditionsMet;
+    } else {
+      const sourceDataValue = Data.getSource(data, component.show_when.field);
+      return meetsCondition(component.show_when, sourceDataValue);
+    }
+  }
+  return true;
+};
+
+export default showComponent;

--- a/src/utils/Component/showComponent.test.js
+++ b/src/utils/Component/showComponent.test.js
@@ -1,0 +1,68 @@
+// Local imports
+import showComponent from './showComponent';
+
+describe('utils', () => {
+
+  describe('Component', () => {
+    
+    describe('show', () => {
+
+      it('should not show when there are no options', () => {
+        expect(showComponent(null, null)).toBeFalsy();
+      });
+
+      it('should not show when hidden and disabled', () => {
+        expect(showComponent({ hidden: true, disabled: true }, null)).toBeFalsy();
+      });
+
+      it('should show when hidden but not disabled', () => {
+        expect(showComponent({ hidden: true }, null)).toBeTruthy();
+      });
+
+      it('should show when disabled but not hidden', () => {
+        expect(showComponent({ disabled: true }, null)).toBeTruthy();
+      });
+
+      it('should show when a single show_when condition is met', () => {
+        const COMPONENT = {
+          show_when: { field: 'alpha', op: 'eq', value: 'bravo' }
+        };
+        const DATA = { alpha: 'bravo' };
+        expect(showComponent(COMPONENT, DATA)).toBeTruthy();
+      });
+
+      it('should not show when a single show_when condition is not met', () => {
+        const COMPONENT = {
+          show_when: { field: 'alpha', op: 'eq', value: 'bravo' }
+        };
+        const DATA = { alpha: 'charlie' };
+        expect(showComponent(COMPONENT, DATA)).toBeFalsy();
+      });
+
+      it('should show when multiple show_when conditions are met', () => {
+        const COMPONENT = {
+          show_when: [
+            { field: 'alpha', op: 'eq', value: 'bravo' },
+            { field: 'charlie', op: 'eq', value: 'delta' },
+          ]
+        };
+        const DATA = { alpha: 'bravo', charlie: 'delta' };
+        expect(showComponent(COMPONENT, DATA)).toBeTruthy();
+      });
+
+      it('should not show when one of multiple show_when conditions is not met', () => {
+        const COMPONENT = {
+          show_when: [
+            { field: 'alpha', op: 'eq', value: 'bravo' },
+            { field: 'charlie', op: 'eq', value: 'delta' },
+          ]
+        };
+        const DATA = { alpha: 'bravo', charlie: 'echo' };
+        expect(showComponent(COMPONENT, DATA)).toBeFalsy();
+      });
+
+    });
+
+  });
+
+});

--- a/src/utils/Data/getSourceData.js
+++ b/src/utils/Data/getSourceData.js
@@ -1,3 +1,18 @@
+/**
+ * Gets the value of a field within the top-level JSON form data,
+ * based on a dot-separated field identifier.
+ * 
+ * Example:
+ *   getSourceData({
+ *     'alpha': {
+ *       'bravo': 'Charlie'
+ *     }
+ *   }, 'alpha.bravo') will return the value 'Charlie'.
+ * 
+ * @param {object} data The top-level JSON form data to iterate through.
+ * @param {string} fieldId The dot-separated path to the field.
+ * @returns The value of the field specified.
+ */
 const getSourceData = (data, fieldId) => {
   if (!fieldId) {
     return undefined;

--- a/src/utils/Data/getSourceData.js
+++ b/src/utils/Data/getSourceData.js
@@ -1,0 +1,10 @@
+const getSourceData = (data, fieldId) => {
+  if (!fieldId) {
+    return undefined;
+  }
+  return fieldId.split('.').reduce((obj, prop) => {
+    return obj ? obj[prop] : undefined;
+  }, data);
+};
+
+export default getSourceData;

--- a/src/utils/Data/getSourceData.test.js
+++ b/src/utils/Data/getSourceData.test.js
@@ -1,0 +1,90 @@
+// Local imports
+import getSourceData from './getSourceData';
+
+describe('utils', () => {
+
+  describe('Data', () => {
+
+    describe('getSourceData', () => {
+      it('should return the value at the top level', () => {
+        const FIELD_ID = 'field';
+        const VALUE = 'value';
+        const DATA = { [FIELD_ID]: VALUE };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toEqual(VALUE);
+      });
+      it('should return a nested value', () => {
+        const FIELD_ID = 'field.nested';
+        const VALUE = 'nested value';
+        const DATA = { field: { nested: VALUE } };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toEqual(VALUE);
+      });
+      it('should return a deeply nested value', () => {
+        const FIELD_ID = 'field.nested.and.even.further.down';
+        const VALUE = 'deeply nested value';
+        const DATA = { field: { nested: { and: { even: { further: { down: VALUE } } } } } };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toEqual(VALUE);
+      });
+      it('should handle null data', () => {
+        const FIELD_ID = 'field.nested';
+        const value = getSourceData(null, FIELD_ID);
+        expect(value).toBeUndefined();
+      });
+      it('should handle undefined data', () => {
+        const FIELD_ID = 'field.nested';
+        const value = getSourceData(undefined, FIELD_ID);
+        expect(value).toBeUndefined();
+      });
+      it('should handle missing value', () => {
+        const FIELD_ID = 'field.nested';
+        const VALUE = 'other value';
+        const DATA = { field: { other: VALUE } };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toBeUndefined();
+      });
+      it('should handle null fieldId', () => {
+        const VALUE = 'value';
+        const DATA = { field: VALUE };
+        const value = getSourceData(DATA, null);
+        expect(value).toBeUndefined();
+      });
+      it('should handle undefined fieldId', () => {
+        const VALUE = 'value';
+        const DATA = { field: VALUE };
+        const value = getSourceData(DATA, undefined);
+        expect(value).toBeUndefined();
+      });
+      it('should handle empty fieldId', () => {
+        const VALUE = 'value';
+        const DATA = { field: VALUE };
+        const value = getSourceData(DATA, '');
+        expect(value).toBeUndefined();
+      });
+      it('should handle fieldId with trailing dot', () => {
+        const FIELD_ID = 'field.';
+        const VALUE = 'value';
+        const DATA = { field: VALUE };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toBeUndefined();
+      });
+      it('should handle fieldId with leading dot', () => {
+        const FIELD_ID = '.field';
+        const VALUE = 'value';
+        const DATA = { field: VALUE };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toBeUndefined();
+      });
+      it('should handle fieldId that is just a dot', () => {
+        const FIELD_ID = '.';
+        const VALUE = 'value';
+        const DATA = { field: VALUE };
+        const value = getSourceData(DATA, FIELD_ID);
+        expect(value).toBeUndefined();
+      });
+    });
+
+  });
+
+});

--- a/src/utils/Data/index.js
+++ b/src/utils/Data/index.js
@@ -1,5 +1,6 @@
 // Local imports
 import getSourceData from './getSourceData';
+
 const Data = {
   getSource: getSourceData,
 };

--- a/src/utils/Data/index.js
+++ b/src/utils/Data/index.js
@@ -1,0 +1,7 @@
+// Local imports
+import getSourceData from './getSourceData';
+const Data = {
+  getSource: getSourceData,
+};
+
+export default Data;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,11 @@
+// Global imports
+import { Utils as HOUtils } from '@ukhomeoffice/cop-react-components';
+
+// Local imports
+import meetsCondition from './meetsCondition';
+const Utils = {
+  meetsCondition,
+  ...HOUtils
+};
+
+export default Utils;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,8 +2,12 @@
 import { Utils as HOUtils } from '@ukhomeoffice/cop-react-components';
 
 // Local imports
+import Component from './Component';
+import Data from './Data';
 import meetsCondition from './meetsCondition';
 const Utils = {
+  Component,
+  Data,
   meetsCondition,
   ...HOUtils
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ import { Utils as HOUtils } from '@ukhomeoffice/cop-react-components';
 import Component from './Component';
 import Data from './Data';
 import meetsCondition from './meetsCondition';
+
 const Utils = {
   Component,
   Data,

--- a/src/utils/meetsCondition.js
+++ b/src/utils/meetsCondition.js
@@ -1,0 +1,55 @@
+const getComparisonValue = (condition) => {
+  if (['in', 'nin'].includes(condition.op)) {
+    return condition.values;
+  }
+  return condition.value;
+};
+
+/**
+ * Looks at a condition object to see if the supplied value meets it.
+ * The condition object contains an `op` property, along with a comparator
+ * `value` (or `values`).
+ * 
+ * The evaluation is strict - i.e., it matches the value AND the type.
+ * 
+ * @param {object} condition The condition object.
+ * @param {*} value The value to test against the condition.
+ * 
+ * @returns A boolean indicating whether the value meets the condition.
+ */
+const meetsCondition = (condition, value) => {
+  if (condition && typeof(condition) === 'object') {
+    const compare = getComparisonValue(condition);
+    switch (condition.op) {
+      case '=':
+      case 'eq': {
+        return compare === value;
+      }
+      case '!=':
+      case '<>':
+      case 'ne':
+      case 'neq': {
+        return compare !== value;
+      }
+      case 'in': {
+        if (Array.isArray(compare)) {
+          return compare.includes(value);
+        }
+        // If it's not an array, nothing can be IN it, so it must fail the condition.
+        return false;
+      }
+      case 'nin': {
+        if (Array.isArray(compare)) {
+          return compare.includes(value) === false;
+        }
+        // If it's not an array, nothing can be IN it, so it must meet the condition.
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+  return true;
+};
+
+export default meetsCondition;

--- a/src/utils/meetsCondition.test.js
+++ b/src/utils/meetsCondition.test.js
@@ -1,0 +1,319 @@
+// Local imports
+import Utils from '.';
+
+describe('utils', () => {
+
+  describe('meetsCondition', () => {
+    const getCondition = (operator, val) => {
+      if (['in', 'nin'].includes(operator)) {
+        return { op: operator, values: val };
+      }
+      return { op: operator, value: val };
+    };
+    const TEST_VALUES = ['a', 'b', 3, 4, null, undefined, true, false, 0];
+
+    describe('equality operators', () => {
+      ['eq', '='].forEach(op => {
+        describe(`operator ${op}`, () => {
+          // Should match...
+          it('should match two nulls', () => {
+            const VALUE = null;
+            const CONDITION = getCondition(op, null);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two undefineds', () => {
+            const VALUE = undefined;
+            const CONDITION = getCondition(op, undefined);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two identical strings', () => {
+            const VALUE = 'value';
+            const CONDITION = getCondition(op, 'value');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two empty strings', () => {
+            const VALUE = '';
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two identical numbers', () => {
+            const VALUE = 3;
+            const CONDITION = getCondition(op, 3);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two zeroes', () => {
+            const VALUE = 0;
+            const CONDITION = getCondition(op, 0);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two boolean trues', () => {
+            const VALUE = true;
+            const CONDITION = getCondition(op, true);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match two boolean falses', () => {
+            const VALUE = false;
+            const CONDITION = getCondition(op, false);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+    
+          // Should reject...
+          it('should reject a null and undefined', () => {
+            const VALUE = null;
+            const CONDITION = getCondition(op, undefined);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject a null and empty string', () => {
+            const VALUE = null;
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject an undefined and empty string', () => {
+            const VALUE = undefined;
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject a string of just whitespace and empty string', () => {
+            const VALUE = ' ';
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it(`should reject the string number '3' and the number 3`, () => {
+            const VALUE = '3';
+            const CONDITION = getCondition(op, 3);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject a boolean true and the number 1', () => {
+            const VALUE = true;
+            const CONDITION = getCondition(op, 1);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject a boolean false and a zero', () => {
+            const VALUE = false;
+            const CONDITION = getCondition(op, 0);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+    
+        });
+
+      });
+    });
+
+    describe('inequality operators', () => {
+
+      ['ne', 'neq', '!=', '<>'].forEach(op => {
+
+        describe(`operator ${op}`, () => {
+          
+          // Should reject...
+          it('should reject two nulls', () => {
+            const VALUE = null;
+            const CONDITION = getCondition(op, null);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two undefineds', () => {
+            const VALUE = undefined;
+            const CONDITION = getCondition(op, undefined);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two identical strings', () => {
+            const VALUE = 'value';
+            const CONDITION = getCondition(op, 'value');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two empty strings', () => {
+            const VALUE = '';
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two identical numbers', () => {
+            const VALUE = 3;
+            const CONDITION = getCondition(op, 3);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two zeroes', () => {
+            const VALUE = 0;
+            const CONDITION = getCondition(op, 0);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two boolean trues', () => {
+            const VALUE = true;
+            const CONDITION = getCondition(op, true);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+          it('should reject two boolean falses', () => {
+            const VALUE = false;
+            const CONDITION = getCondition(op, false);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+          });
+    
+          // Should match...
+          it('should match a null and undefined', () => {
+            const VALUE = null;
+            const CONDITION = getCondition(op, undefined);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match a null and empty string', () => {
+            const VALUE = null;
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match an undefined and empty string', () => {
+            const VALUE = undefined;
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match a string of just whitespace and empty string', () => {
+            const VALUE = ' ';
+            const CONDITION = getCondition(op, '');
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it(`should match the string number '3' and the number 3`, () => {
+            const VALUE = '3';
+            const CONDITION = getCondition(op, 3);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match a boolean true and the number 1', () => {
+            const VALUE = true;
+            const CONDITION = getCondition(op, 1);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+          it('should match a boolean false and a zero', () => {
+            const VALUE = false;
+            const CONDITION = getCondition(op, 0);
+            expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+          });
+    
+        });
+      });
+
+    });
+
+    describe('operator in', () => {
+      const op = 'in';
+      
+      // Should match...
+      it('should match a string that is in the values array', () => {
+        const VALUE = 'alpha';
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie']);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+      });
+      it('should match a number that is in the values array', () => {
+        const VALUE = 4;
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie', 4]);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+      });
+
+      // Should reject...
+      it('should reject a string that is missing from the values array', () => {
+        const VALUE = 'delta';
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie']);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+      });
+      it('should reject a number that is missing from the values array', () => {
+        const VALUE = 4;
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie']);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+      });
+      it('should reject everything when the values array is empty', () => {
+        const CONDITION = getCondition(op, []);
+        ['a', 'b', 'c', 'd', 'e', 6, 7, 8, 9, 'ten'].forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeFalsy();
+        });
+      });
+      it('should reject everything when the values array is null', () => {
+        const CONDITION = getCondition(op, null);
+        ['a', 'b', 'c', 'd', 'e', 6, 7, 8, 9, 'ten'].forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeFalsy();
+        });
+      });
+
+    });
+
+    describe('operator nin', () => {
+      const op = 'nin';
+      
+      // Should reject...
+      it('should reject a string that is in the values array', () => {
+        const VALUE = 'alpha';
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie']);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+      });
+      it('should reject a number that is in the values array', () => {
+        const VALUE = 4;
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie', 4]);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeFalsy();
+      });
+
+      // Should match...
+      it('should match a string that is missing from the values array', () => {
+        const VALUE = 'delta';
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie']);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+      });
+      it('should match a number that is missing from the values array', () => {
+        const VALUE = 4;
+        const CONDITION = getCondition(op, ['alpha', 'bravo', 'charlie']);
+        expect(Utils.meetsCondition(CONDITION, VALUE)).toBeTruthy();
+      });
+      it('should match anything when the values array is empty', () => {
+        const CONDITION = getCondition(op, []);
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeTruthy();
+        });
+      });
+      it('should match anything when the values array is null', () => {
+        const CONDITION = getCondition(op, null);
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeTruthy();
+        });
+      });
+
+    });
+
+    describe('unknown operator', () => {
+      const op = 'definitely_not_a_real_operator';
+
+      it('should reject anything regardless of the value', () => {
+        const CONDITION = getCondition(op, 'a');
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeFalsy();
+        });
+      });
+      it('should accept anything even with a null value', () => {
+        const CONDITION = getCondition(op, null);
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeFalsy();
+        });
+      });
+      it('should accept anything even with a undefined value', () => {
+        const CONDITION = getCondition(op, null);
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(CONDITION, value)).toBeFalsy();
+        });
+      });
+    });
+
+    describe('invalid condition', () => {
+
+      it('should accept anything when the condition is null', () => {
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(null, value)).toBeTruthy();
+        });
+      });
+      it('should accept anything when the condition is undefined', () => {
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition(undefined, value)).toBeTruthy();
+        });
+      });
+      it('should accept anything when the condition is not an object', () => {
+        TEST_VALUES.forEach(value => {
+          expect(Utils.meetsCondition('condition', value)).toBeTruthy();
+        });
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
### Description
Mechanism for determining whether a field should be shown or not, based on the value of one or more other fields.
https://support.cop.homeoffice.gov.uk/browse/COP-9029


### To test
This should be covered by the unit tests within this commit. For the benefit of the QA team, this will be demonstrable within the Storybook stories in a subsequent PR.