### PR TITLE
COP-9577: Add FormPage component

### DIFF
--- a/src/components/FormPage/FormPage.jsx
+++ b/src/components/FormPage/FormPage.jsx
@@ -1,0 +1,73 @@
+// Global imports
+import { ErrorSummary, LargeHeading } from '@ukhomeoffice/cop-react-components';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+
+// Local imports.
+import Utils from '../../utils';
+import FormComponent from '../FormComponent';
+import PageActions from '../PageActions';
+
+// Styles
+import './FormPage.scss';
+
+export const DEFAULT_CLASS = 'hods-form';
+const FormPage = ({
+  page,
+  onAction,
+  classBlock,
+  classModifiers,
+  className
+}) => {
+  const [patch, setPatch] = useState({});
+  const [errors, setErrors] = useState([]);
+
+  /**
+   * Handle the state of the data directly within the page.
+   * This is so that the overall form data isn't affected until such
+   * time as the onAction handler is invoked.
+  */
+  const onPageChange = ({ target }) => {
+    page.formData[target.name] = target.value;
+    setPatch(prev => ({
+      ...prev,
+      [target.name]: target.value
+    }));
+  };
+
+  const classes = Utils.classBuilder(classBlock, classModifiers, className);
+  return (
+    <div className={classes('page')} key={page.id}>
+      {page.title && <LargeHeading>{page.title}</LargeHeading>}
+      {errors && errors.length > 0 && <ErrorSummary errors={errors} />}
+      {page.components.map((component, index) => (
+        <FormComponent key={index}
+          component={component}
+          onChange={onPageChange}
+          value={page.formData[component.fieldId] || ''} />
+      ))}
+      <PageActions actions={page.actions} onAction={(action) => onAction(action, patch, setErrors)} />
+    </div>
+  );
+};
+
+FormPage.propTypes = {
+  page: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    components: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object])).isRequired,
+    actions: PropTypes.array,
+    formData: PropTypes.object.isRequired
+  }).isRequired,
+  onAction: PropTypes.func.isRequired,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+FormPage.defaultProps = {
+  classBlock: DEFAULT_CLASS,
+  classModifiers: []
+};
+
+export default FormPage;

--- a/src/components/FormPage/FormPage.scss
+++ b/src/components/FormPage/FormPage.scss
@@ -1,0 +1,7 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+
+.hods-form {
+  &__page {
+    display: block;
+  }
+}

--- a/src/components/FormPage/FormPage.stories.mdx
+++ b/src/components/FormPage/FormPage.stories.mdx
@@ -1,0 +1,118 @@
+<!-- Global imports -->
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Details, Heading, Link } from '@ukhomeoffice/cop-react-components';
+import withMock from 'storybook-addon-mock';
+
+<!-- Local imports -->
+import Utils from '../../utils';
+import FormPage from './FormPage';
+
+<!-- JSON documents -->
+import CIVIL_SERVANT from '../../json/areYouACivilServant.json';
+import GRADE from '../../json/grade.json';
+import TEAMS from '../../json/team.json';
+import USER_PROFILE_DATA from '../../json/userProfile.data.json';
+import USER_PROFILE from '../../json/userProfile.json';
+
+<Meta title="Components/Form page" id="D-FormPage" component={ FormPage } decorators={[withMock]} />
+
+<Heading size="xl" caption="Components">Form page</Heading>
+
+Renders a page on a form with <Link href="https://ukhomeoffice.github.io/cop-react-components/?path=/docs/d-alert--default-story">COP React components</Link>,
+on the basis of a <Link href="/?path=/docs/f-json-page">JSON</Link> configuration.
+
+<Canvas withToolbar>
+  <Story name="Default" parameters={{
+    mockData: [
+      {
+        url: `${USER_PROFILE_DATA.environmentContext.referenceDataUrl}/v2/entities/areYouACivilServant`,
+        method: 'GET',
+        status: 200,
+        response: CIVIL_SERVANT
+      },
+      {
+        url: `${USER_PROFILE_DATA.environmentContext.referenceDataUrl}/v2/entities/grade`,
+        method: 'GET',
+        status: 200,
+        response: GRADE
+      },
+      {
+        url: `${USER_PROFILE_DATA.environmentContext.referenceDataUrl}/v1/entities/team`,
+        method: 'GET',
+        status: 200,
+        response: TEAMS
+      }
+    ]
+  }}>
+    {() => {
+      const PAGE_JSON = USER_PROFILE.pages.find(p => p.id === 'civil-servant-status');
+      const PAGE = Utils.FormPage.get(PAGE_JSON, USER_PROFILE.components, { ...USER_PROFILE_DATA });
+      const ON_ACTION = (action, patch, onError) => {
+        console.log('action invoked', action, patch);
+      };
+      return (
+        <FormPage page={PAGE} onAction={ON_ACTION} />
+      );
+    }}
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ FormPage } />
+</Details>
+
+
+## Variants
+### With `autocomplete`
+<Canvas>
+  <Story name="With autocomplete" parameters={{
+    mockData: [
+      {
+        url: `${USER_PROFILE_DATA.environmentContext.referenceDataUrl}/v2/entities/areYouACivilServant`,
+        method: 'GET',
+        status: 200,
+        response: CIVIL_SERVANT
+      },
+      {
+        url: `${USER_PROFILE_DATA.environmentContext.referenceDataUrl}/v2/entities/grade`,
+        method: 'GET',
+        status: 200,
+        response: GRADE
+      },
+      {
+        url: `${USER_PROFILE_DATA.environmentContext.referenceDataUrl}/v1/entities/team`,
+        method: 'GET',
+        status: 200,
+        response: TEAMS
+      }
+    ]
+  }}>
+    {() => {
+      const PAGE_JSON = USER_PROFILE.pages.find(p => p.id === 'team-name');
+      const PAGE = Utils.FormPage.get(PAGE_JSON, USER_PROFILE.components, { ...USER_PROFILE_DATA });
+      const ON_ACTION = (action, patch, onError) => {
+        console.log('action invoked', action, patch);
+      };
+      return (
+        <FormPage page={PAGE} onAction={ON_ACTION} />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Without editable controls
+
+<Canvas>
+  <Story name="Without editable controls">
+    {() => {
+      const PAGE_JSON = USER_PROFILE.pages.find(p => p.id === 'add-or-change-line-manager');
+      const PAGE = Utils.FormPage.get(PAGE_JSON, USER_PROFILE.components, { ...USER_PROFILE_DATA });
+      const ON_ACTION = (action, patch, onError) => {
+        console.log('action invoked', action, patch);
+      };
+      return (
+        <FormPage page={PAGE} onAction={ON_ACTION} />
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/FormPage/FormPage.test.js
+++ b/src/components/FormPage/FormPage.test.js
@@ -1,0 +1,148 @@
+// Global imports
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+// Local imports
+import { DEFAULT_ACTIONS, DEFAULT_LABEL } from '../PageActions/ActionButton';
+import FormPage, { DEFAULT_CLASS } from './FormPage';
+
+describe('components', () => {
+
+  describe('FormPage', () => {
+
+    const TEXT = { id: 'text', fieldId: 'text', type: 'text', label: 'Text component', hint: 'Text hint' };
+    const VALUE = 'Text value';
+    const PAGE = {
+      id: 'pageId',
+      title: 'Page 1',
+      components: [ TEXT ],
+      actions: ['submit'],
+      formData: { text: VALUE }
+    };
+    const ON_ACTION_CALLS = [];
+    const ON_ACTION = (action, patch, onError) => {
+      ON_ACTION_CALLS.push({ action, patch, onError });
+    };
+
+    beforeEach(() => {
+      PAGE.formData = { text: VALUE };
+      ON_ACTION_CALLS.length = 0;
+    });
+
+    it('should render a submit page correctly', async () => {
+      const { container } = render(
+        <FormPage page={PAGE} onAction={ON_ACTION} />
+      );
+      const page = container.childNodes[0];
+      expect(page.tagName).toEqual('DIV');
+      expect(page.classList).toContain(`${DEFAULT_CLASS}__page`);
+      const heading = page.childNodes[0];
+      expect(heading.classList).toContain('govuk-heading-l');
+      expect(heading.textContent).toEqual(PAGE.title);
+      const formGroup = page.childNodes[1];
+      expect(formGroup.tagName).toEqual('DIV');
+      expect(formGroup.classList).toContain('govuk-form-group');
+      const label = formGroup.childNodes[0];
+      expect(label.tagName).toEqual('LABEL');
+      expect(label.classList).toContain('govuk-label');
+      expect(label.textContent).toEqual(`${TEXT.label} (optional)`);
+      expect(label.getAttribute('for')).toEqual(TEXT.fieldId);
+      const hint = formGroup.childNodes[1];
+      expect(hint.tagName).toEqual('SPAN');
+      expect(hint.classList).toContain('govuk-hint');
+      expect(hint.textContent).toEqual(TEXT.hint);
+      const input = formGroup.childNodes[2];
+      expect(input.tagName).toEqual('INPUT');
+      expect(input.classList).toContain('govuk-input');
+      expect(input.id).toEqual(TEXT.fieldId);
+      expect(input.value).toEqual(VALUE);
+      const buttonGroup = page.childNodes[2];
+      expect(buttonGroup.tagName).toEqual('DIV');
+      expect(buttonGroup.classList).toContain('govuk-button-group');
+      const button = buttonGroup.childNodes[0];
+      expect(button.tagName).toEqual('BUTTON');
+      expect(button.classList).toContain('govuk-button');
+      expect(button.textContent).toEqual(DEFAULT_LABEL);
+    });
+
+    it('should handle a page change appropriately', async () => {
+      const { container } = render(
+        <FormPage page={PAGE} onAction={ON_ACTION} />
+      );
+      const page = container.childNodes[0];
+      expect(page.tagName).toEqual('DIV');
+
+      // Change the input.
+      const input = page.childNodes[1].childNodes[2];
+      const NEW_VALUE = `${VALUE}.`;
+      const EVENT = { target: { name: TEXT.fieldId, value: NEW_VALUE } };
+      fireEvent.change(input, EVENT);
+
+      // And confirm the formData has been changed.
+      expect(PAGE.formData.text).toEqual(NEW_VALUE);
+    });
+
+    it('should handle a page action appropriately', async () => {
+      const { container } = render(
+        <FormPage page={PAGE} onAction={ON_ACTION} />
+      );
+      const page = container.childNodes[0];
+
+      // Change the input.
+      const input = page.childNodes[1].childNodes[2];
+      const NEW_VALUE = `${VALUE}.`;
+      const CHANGE_EVENT = { target: { name: TEXT.fieldId, value: NEW_VALUE } };
+      fireEvent.change(input, CHANGE_EVENT);
+
+      // Then click the action button.
+      const button = page.childNodes[2].childNodes[0];
+      fireEvent.click(button, {});
+
+      // And confirm an appropriate action was received.
+      expect(ON_ACTION_CALLS.length).toEqual(1);
+      expect(PAGE.formData.text).toEqual(NEW_VALUE);
+      expect(ON_ACTION_CALLS[0].action).toEqual(DEFAULT_ACTIONS.submit);
+      expect(ON_ACTION_CALLS[0].patch).toEqual({ text: NEW_VALUE });
+    });
+
+    it('should display errors appropriately', async () => {
+      const ERRORS = [{ id: TEXT.id, error: 'Invalid value' }];
+      const THROW_ERROR_ON_ACTION = (action, patch, onError) => {
+        ON_ACTION_CALLS.push({ action, patch, onError });
+        onError(ERRORS);
+      };
+      const { container } = render(
+        <FormPage page={PAGE} onAction={THROW_ERROR_ON_ACTION} />
+      );
+      const page = container.childNodes[0];
+
+      // Change the input.
+      const input = page.childNodes[1].childNodes[2];
+      const NEW_VALUE = `${VALUE}.`;
+      const CHANGE_EVENT = { target: { name: TEXT.fieldId, value: NEW_VALUE } };
+      fireEvent.change(input, CHANGE_EVENT);
+
+      // Then click the action button, which should call the onError callback method.
+      const button = page.childNodes[2].childNodes[0];
+      fireEvent.click(button, {});
+
+      // And confirm the page error is now displayed.
+      const errorSummary = page.childNodes[1];
+      expect(errorSummary.tagName).toEqual('DIV');
+      expect(errorSummary.id).toEqual('error-summary');
+      expect(errorSummary.classList).toContain('govuk-error-summary');
+      const errorList = errorSummary.childNodes[1].childNodes[0];
+      expect(errorList.tagName).toEqual('UL');
+      expect(errorList.classList).toContain('govuk-error-summary__list');
+      expect(errorList.childNodes.length).toEqual(ERRORS.length);
+      const error = errorList.childNodes[0];
+      expect(error.tagName).toEqual('LI');
+      const errorLink = error.childNodes[0];
+      expect(errorLink.tagName).toEqual('A');
+      expect(errorLink.textContent).toEqual(ERRORS[0].error);
+      expect(errorLink.getAttribute('href')).toEqual(`#${ERRORS[0].id}`);
+    });
+
+  });
+
+});

--- a/src/components/FormPage/index.js
+++ b/src/components/FormPage/index.js
@@ -1,0 +1,3 @@
+import FormPage from './FormPage';
+
+export default FormPage;

--- a/src/components/PageActions/ActionButton.jsx
+++ b/src/components/PageActions/ActionButton.jsx
@@ -28,4 +28,8 @@ ActionButton.propTypes = {
   onAction: PropTypes.func.isRequired
 };
 
+ActionButton.defaultProps = {
+  action: ''
+};
+
 export default ActionButton;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,8 @@
 // Local imports
 import FormComponent from './FormComponent';
+import FormPage from './FormPage';
 
 export {
   FormComponent,
+  FormPage,
 };


### PR DESCRIPTION
### Description
Added a `FormPage` component for rendering an entire page of a form, as described in the JSON, along with unit tests and Storybook stories.

This PR concludes the set for https://support.cop.homeoffice.gov.uk/browse/COP-9577.

### To test
The component has 100% unit test coverage and the rendering can be observed within the accompanying Storybook story.