### PR TITLE
COP-9700: Add FormTypes and HubFormats models

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // Local imports
 import { addHook } from './hooks/useHooks';
+import { FormTypes, HubFormats } from './models';
 import Utils from './utils';
 
 const intercepts = {
@@ -8,5 +9,7 @@ const intercepts = {
 
 export {
   intercepts,
+  FormTypes,
+  HubFormats,
   Utils
 };

--- a/src/models/FormTypes.js
+++ b/src/models/FormTypes.js
@@ -1,0 +1,13 @@
+const TYPE_FORM = 'form';
+const TYPE_CHECK_YOUR_ANSWERS = 'cya';
+const TYPE_HUB_AND_SPOKE = 'hub-and-spoke';
+const TYPE_WIZARD = 'wizard';
+
+const FormTypes = {
+  FORM: TYPE_FORM,
+  CYA: TYPE_CHECK_YOUR_ANSWERS,
+  HUB: TYPE_HUB_AND_SPOKE,
+  WIZARD: TYPE_WIZARD
+};
+
+export default FormTypes;

--- a/src/models/HubFormats.js
+++ b/src/models/HubFormats.js
@@ -1,0 +1,7 @@
+const HUB_FORMAT_CYA = 'CYA';
+
+const HubFormats = {
+  CYA: HUB_FORMAT_CYA
+};
+
+export default HubFormats;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,10 @@
 // Local imports
 import ComponentTypes from './ComponentTypes';
+import FormTypes from './FormTypes';
+import HubFormats from './HubFormats';
 
 export {
   ComponentTypes,
+  FormTypes,
+  HubFormats
 };


### PR DESCRIPTION
### Description
Added the `FormTypes` and `HubFormats` models, which are essentially enumerations that are used to indicate how the form should be set up.