### PR TITLE
COP-9700: Add helper functions for FormRenderer

### DIFF
--- a/src/components/FormRenderer/helpers/getCYA.js
+++ b/src/components/FormRenderer/helpers/getCYA.js
@@ -1,0 +1,19 @@
+// Local imports
+import { HubFormats } from '../../../models';
+
+/**
+ * Gets a configuration object for the Check your answers screen.
+ * @param {string} pageId The current page identifier.
+ * @param {object} hub The hub, if there is one.
+ * @returns A configuration object for the Check your answers screen.
+ */
+const getCYA = (pageId, hub) => {
+  if (pageId === 'hub' && hub === HubFormats.CYA) {
+    return { title: '' };
+  } else if (pageId === HubFormats.CYA) {
+    return {};
+  }
+  return undefined;
+};
+
+export default getCYA;

--- a/src/components/FormRenderer/helpers/getCYA.test.js
+++ b/src/components/FormRenderer/helpers/getCYA.test.js
@@ -1,0 +1,40 @@
+// Local imports
+import { HubFormats } from '../../../models';
+import getCYA from './getCYA';
+
+describe('components', () => {
+
+  describe('FormRenderer', () => {
+
+    describe('helpers', () => {
+      const HUB = { id: 'hub', components: [] };
+
+      describe('getCYA', () => {
+
+        it('should give an empty object if the pageId is "CYA"', () => {
+          expect(getCYA(HubFormats.CYA)).toEqual({});
+        });
+
+        it('should give an object with a blank title if the pageId is "hub" and the hub is the CYA', () => {
+          expect(getCYA('hub', HubFormats.CYA)).toEqual({ title: '' });
+        });
+
+        it('should give undefined if pageId is "hub" and the hub is NOT the CYA', () => {
+          expect(getCYA('hub', HUB)).toBeUndefined();
+        });
+
+        it('should give undefined if pageId is NOT "hub" and the hub is NOT the CYA', () => {
+          expect(getCYA('bob', HUB)).toBeUndefined();
+        });
+
+        it('should give undefined if pageId is NOT "hub" and the hub is the CYA', () => {
+          expect(getCYA('bob', HubFormats.CYA)).toBeUndefined();
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/src/components/FormRenderer/helpers/getFormState.js
+++ b/src/components/FormRenderer/helpers/getFormState.js
@@ -1,0 +1,20 @@
+// Local imports
+import getCYA from './getCYA';
+import getPage from './getPage';
+
+/**
+ * Sets up the state of the form, including the current page and the Check your answers screen.
+ * @param {string} pageId The current page identifier.
+ * @param {Array} pages All of the pages in the form.
+ * @param {object} hub The hub, if there is one.
+ * @returns The current state of the form.
+ */
+const getFormState = (pageId, pages, hub) => {
+  return {
+    pageId,
+    cya: getCYA(pageId, hub),
+    page: getPage(pageId, pages, hub)
+  };
+};
+
+export default getFormState;

--- a/src/components/FormRenderer/helpers/getFormState.test.js
+++ b/src/components/FormRenderer/helpers/getFormState.test.js
@@ -1,0 +1,57 @@
+// Local imports
+import { HubFormats } from '../../../models';
+import getFormState from './getFormState';
+
+describe('components', () => {
+
+  describe('FormRenderer', () => {
+
+    describe('helpers', () => {
+      const HUB = { id: 'hub', components: [] };
+      const PAGES = [
+        { id: 'alpha', components: ['x'] },
+        { id: 'bravo', components: ['y', 'z'] },
+        HUB
+      ];
+
+      describe('getFormState', () => {
+
+        it('should set up accordingly when viewing a hub that is the CYA', () => {
+          expect(getFormState('hub', PAGES, HubFormats.CYA)).toEqual({
+            pageId: 'hub',
+            cya: { title: '' },
+            page: undefined
+          });
+        });
+
+        it('should set up accordingly when viewing a hub that is NOT the CYA', () => {
+          expect(getFormState('hub', PAGES, HUB)).toEqual({
+            pageId: 'hub',
+            cya: undefined,
+            page: HUB
+          });
+        });
+
+        it('should set up accordingly when viewing the CYA', () => {
+          expect(getFormState(HubFormats.CYA, PAGES, HUB)).toEqual({
+            pageId: HubFormats.CYA,
+            cya: {},
+            page: undefined
+          });
+        });
+
+        it('should set up accordingly when viewing a standard page', () => {
+          expect(getFormState('bravo', PAGES, HUB)).toEqual({
+            pageId: 'bravo',
+            cya: undefined,
+            page: { id: 'bravo', components: ['y', 'z'] }
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/src/components/FormRenderer/helpers/getPage.js
+++ b/src/components/FormRenderer/helpers/getPage.js
@@ -1,0 +1,21 @@
+// Local imports
+import { HubFormats } from '../../../models';
+
+/**
+ * Gets the current page to render, which may be undefined if the current page is the "hub".
+ * @param {string} pageId The current page identifier.
+ * @param {Array} pages All of the pages in the form.
+ * @param {object} hub The hub, if there is one.
+ * @returns The current page to render.
+ */
+const getPage = (pageId, pages, hub) => {
+  if (pageId) {
+    if (pageId === 'hub') {
+      return hub === HubFormats.CYA ? undefined : hub;
+    }
+    return pages.find(p => p.id === pageId);
+  }
+  return undefined;
+};
+
+export default getPage;

--- a/src/components/FormRenderer/helpers/getPage.test.js
+++ b/src/components/FormRenderer/helpers/getPage.test.js
@@ -1,0 +1,45 @@
+// Local imports
+import { HubFormats } from '../../../models';
+import getPage from './getPage';
+
+describe('components', () => {
+
+  describe('FormRenderer', () => {
+
+    describe('helpers', () => {
+      const HUB = { id: 'hub', components: [] };
+      const PAGES = [
+        { id: 'alpha', components: ['x'] },
+        { id: 'bravo', components: ['y', 'z'] },
+        HUB
+      ];
+
+      describe('getPage', () => {
+
+        it('should give undefined if the pageId is undefined', () => {
+          expect(getPage(undefined, PAGES, HubFormats.CYA)).toBeUndefined();
+        });
+
+        it('should give undefined if the pageId is "hub" but the hub is the CYA', () => {
+          expect(getPage('hub', PAGES, HubFormats.CYA)).toBeUndefined();
+        });
+
+        it('should give hub if the pageId is "hub" and the hub is NOT the CYA', () => {
+          expect(getPage('hub', PAGES, HUB)).toEqual(HUB);
+        });
+
+        it('should give find the appropriate page if the pageId is not "hub"', () => {
+          expect(getPage('alpha', PAGES, HUB)).toEqual({ id: 'alpha', components: ['x']});
+        });
+
+        it('should give undefined if the pageId is not "hub" and not found in the pages collection', () => {
+          expect(getPage('charlie', PAGES, HUB)).toBeUndefined();
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/src/components/FormRenderer/helpers/index.js
+++ b/src/components/FormRenderer/helpers/index.js
@@ -1,0 +1,6 @@
+// Local imports
+import getFormState from './getFormState';
+
+export {
+  getFormState
+};


### PR DESCRIPTION
### Description
Added helper functions to get the current render state of the form.

### To test
Covered by the accompanying unit tests.