### PR TITLE
COP-9136: Add email address validation

### DIFF
--- a/src/utils/Validate/index.js
+++ b/src/utils/Validate/index.js
@@ -1,10 +1,12 @@
 // Local imports
 import validateComponent from './validateComponent';
+import validateEmail from './validateEmail';
 import validatePage from './validatePage';
 import validateRequired from './validateRequired';
 
 const Validate = {
   component: validateComponent,
+  email: validateEmail,
   page: validatePage,
   required: validateRequired
 };

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -1,5 +1,7 @@
 // Local imports
+import { ComponentTypes } from '../../models';
 import validateRequired from './validateRequired';
+import validateEmail from './validateEmail';
 
 /**
  * Validates a single component.
@@ -14,6 +16,9 @@ const validateComponent = (component, formData) => {
     const value = data[component.fieldId];
     if (component.required) {
       error = validateRequired(value, component.label);
+    }
+    if (!error && component.type === ComponentTypes.EMAIL) {
+      error = validateEmail(value, component.label);
     }
     component.error = error;
   }

--- a/src/utils/Validate/validateComponent.test.js
+++ b/src/utils/Validate/validateComponent.test.js
@@ -44,6 +44,13 @@ describe('utils', () => {
             error: `${LABEL} is required`
           });
         });
+  
+        it('should return no error when the component is of type email but not required', () => {
+          const ID = 'field';
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+          expect(validateComponent(COMPONENT, null)).toBeUndefined();
+        });
 
       });
 
@@ -61,6 +68,54 @@ describe('utils', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+  
+        it('should return no error when the component is required and of type email', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+  
+        it('should return no error when the component is of type email but not required', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+
+      });
+
+      describe('when the value is an invalid email', () => {
+        const ID = 'field';
+        const DATA = { [ID]: 'alpha.bravo@hotmail.com' };
+
+        it('should return no error when the component is not required and not an email type', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+  
+        it('should return no error when the component is required and not an email type', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+  
+        it('should return no error when the component is required and of type email', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            id: ID,
+            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
+          });
+        });
+  
+        it('should return no error when the component is of type email but not required', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            id: ID,
+            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
+          });
         });
 
       });

--- a/src/utils/Validate/validateEmail.js
+++ b/src/utils/Validate/validateEmail.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line no-control-regex
+// const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/i;
+const HODS_EMAIL_REGEX = /^[a-z0-9._-]+@(digital\.)?homeoffice.gov.uk$/i;
+
+/**
+ * Validates an email address, ensuring it is in the correct domain and
+ * complies with the Home Office email address standards.
+ * 
+ * Note that an empty string is not considered invalid. You should use
+ * validateRequired (Validate.required) for that sort of validation.
+ * @param {*} value The value to validate.
+ * @param {string} label The label to use in any error message.
+ * @returns An error if the email address is invalid.
+ */
+const validateEmail = (value, label = '') => {
+  if (!!value) {
+    if (typeof value === 'string') {
+      if (HODS_EMAIL_REGEX.test(value)) {
+        return undefined;
+      }
+    }
+    const name = label ? label.toLowerCase() : 'email address';
+    return `Enter ${name} in the correct format, like jane.doe@homeoffice.gov.uk`;
+  }
+  return undefined;
+};
+
+export default validateEmail;

--- a/src/utils/Validate/validateEmail.test.js
+++ b/src/utils/Validate/validateEmail.test.js
@@ -1,0 +1,61 @@
+// Local imports
+import validateEmail from './validateEmail';
+
+describe('utils', () => {
+
+  describe('Validate', () => {
+
+    describe('email', () => {
+
+      const LABEL = 'Component';
+      const ERROR = `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`;
+
+      // Valid values
+      it('should return no error when the value is a valid .gov.uk address', () => {
+        expect(validateEmail('alpha@homeoffice.gov.uk', LABEL)).toBeUndefined();
+      });
+      it('should return no error when the value is a capitalised digital.homeoffice.gov.uk address', () => {
+        expect(validateEmail('ALPHA.BRAVO@DIGITAL.HOMEOFFICE.GOV.UK', LABEL)).toBeUndefined();
+      });
+      it('should return no error when the value is an empty string', () => {
+        expect(validateEmail('', LABEL)).toBeUndefined();
+      });
+
+      // Invalid values
+      it('should return an error when the value is an empty object', () => {
+        expect(validateEmail({}, LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when the value is an array', () => {
+        expect(validateEmail(['bob'], LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when the value is numeric', () => {
+        expect(validateEmail(24, LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when the value is in the wrong domain', () => {
+        expect(validateEmail('alpha@domain.com', LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when the domain contains spaces', () => {
+        expect(validateEmail('alpha.bravo@digital homeoffice.gov.uk', LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when the value has no TLD', () => {
+        expect(validateEmail('alpha.bravo@homeoffice', LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when there is no name', () => {
+        expect(validateEmail('@homeoffice.gov.uk', LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when there is no @ symbol', () => {
+        expect(validateEmail('alpha.bravo.homeoffice.gov.uk', LABEL)).toEqual(ERROR);
+      });
+      it('should return an error when the name contains spaces', () => {
+        expect(validateEmail('alpha bravo@digital.homeoffice.gov.uk', LABEL)).toEqual(ERROR);
+      });
+      it('should use a default label when none is specified', () => {
+        const DEFAULT_ERROR = 'Enter email address in the correct format, like jane.doe@homeoffice.gov.uk'
+        expect(validateEmail(['bob'], undefined)).toEqual(DEFAULT_ERROR);
+      });
+
+    });
+
+  });
+
+});

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -70,6 +70,85 @@ describe('utils', () => {
           expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
         });
 
+        it('should return no errors when none of the components are required but are all email types', () => {
+          const COMPONENTS = [
+            setup('alpha', ComponentTypes.EMAIL, 'Alpha', false),
+            setup('bravo', ComponentTypes.EMAIL, 'Bravo', false)
+          ];
+          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+        });
+
+        it('should return no errors when all of the components are required and email types', () => {
+          const COMPONENTS = [
+            setup('alpha', ComponentTypes.EMAIL, 'Alpha', true),
+            setup('bravo', ComponentTypes.EMAIL, 'Bravo', true)
+          ];
+          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+        });
+
+      });
+
+      describe('when the form data has one field missing and includes an invalid email', () => {
+        const DATA = {
+          alpha: 'alpha.smith@digital.homeoffice.gov.uk',
+          bravo: 'bravo.jones@hotmail.com'
+        };
+
+        it('should return no errors when none of the components are required or email types', () => {
+          const COMPONENTS = [
+            setup('alpha', ComponentTypes.TEXT, 'Alpha', false),
+            setup('bravo', ComponentTypes.TEXT, 'Bravo', false),
+            setup('charlie', ComponentTypes.TEXT, 'Charlie', false)
+          ];
+          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+        });
+
+        it('should return an error for the missing field when all are required but not email types', () => {
+          const COMPONENTS = [
+            setup('alpha', ComponentTypes.TEXT, 'Alpha', true),
+            setup('bravo', ComponentTypes.TEXT, 'Bravo', true),
+            setup('charlie', ComponentTypes.TEXT, 'Charlie', true)
+          ];
+          const RESULT = validatePage(COMPONENTS, DATA);
+          expect(RESULT.length).toEqual(1);
+          expect(RESULT[0]).toEqual({
+            id: 'charlie',
+            error: 'Charlie is required'
+          });
+        });
+
+        it('should return an error for the invalid email field when none are required but all email types', () => {
+          const COMPONENTS = [
+            setup('alpha', ComponentTypes.EMAIL, 'Alpha', false),
+            setup('bravo', ComponentTypes.EMAIL, 'Bravo', false),
+            setup('charlie', ComponentTypes.EMAIL, 'Charlie', false)
+          ];
+          const RESULT = validatePage(COMPONENTS, DATA);
+          expect(RESULT.length).toEqual(1);
+          expect(RESULT[0]).toEqual({
+            id: 'bravo',
+            error: 'Enter bravo in the correct format, like jane.doe@homeoffice.gov.uk'
+          });
+        });
+
+        it('should return an error for both invalid fields when all are required and email types', () => {
+          const COMPONENTS = [
+            setup('alpha', ComponentTypes.EMAIL, 'Alpha', true),
+            setup('bravo', ComponentTypes.EMAIL, 'Bravo', true),
+            setup('charlie', ComponentTypes.EMAIL, 'Charlie', true)
+          ];
+          const RESULT = validatePage(COMPONENTS, DATA);
+          expect(RESULT.length).toEqual(2);
+          expect(RESULT[0]).toEqual({
+            id: 'bravo',
+            error: 'Enter bravo in the correct format, like jane.doe@homeoffice.gov.uk'
+          });
+          expect(RESULT[1]).toEqual({
+            id: 'charlie',
+            error: 'Charlie is required'
+          });
+        });
+
       });
 
     });


### PR DESCRIPTION
### Description
Added a validation mechanism for email addresses. It specifically validates Home Office email addresses and will consider anything else to be invalid. This is invoked on any email components when the page is submitted.

https://support.cop.homeoffice.gov.uk/browse/COP-9136

### To test
Unit tests have been added to test for this behaviour accordingly and it will be visible within any Storybook stories that include email addresses.