### PR TITLE
COP-9748: Format form

### DIFF
--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 
 // Local imports
 import { useHooks } from '../../hooks';
-import { FormTypes } from '../../models';
+import { EventTypes, FormTypes } from '../../models';
 import Utils from '../../utils';
 import CheckYourAnswers from '../CheckYourAnswers';
 import FormPage from '../FormPage';
@@ -85,7 +85,8 @@ const FormRenderer = ({
         handlers.navigate(action, pageId, onPageChange);
       } else {
         // Submit.
-        const submissionData = patch ? { ...data, ...patch } : { ...data };
+        const rawData = patch ? { ...data, ...patch } : { ...data };
+        const submissionData = Utils.Format.form({ pages, components }, rawData, EventTypes.SUBMIT);
         if (patch) {
           setData(submissionData);
         }
@@ -124,7 +125,10 @@ FormRenderer.propTypes = {
   cya: PropTypes.object,
   data: PropTypes.object,
   hooks: PropTypes.shape({
-    onRequest: PropTypes.func
+    onFormLoad: PropTypes.func,
+    onPageChange: PropTypes.func,
+    onRequest: PropTypes.func,
+    onSubmit: PropTypes.func
   }),
   classBlock: PropTypes.string,
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),

--- a/src/json/userProfile.json
+++ b/src/json/userProfile.json
@@ -1,7 +1,6 @@
 {
   "id": "userProfile",
   "version": "1",
-  "newCOP": true,
   "name": "userProfile",
   "title": "Your profile",
   "type": "hub-and-spoke",
@@ -77,6 +76,10 @@
       "label": "Line manager email",
       "hint": "Must be a homeoffice.gov.uk or digital.homeoffice.gov.uk address",
       "type": "email",
+      "format": {
+        "type": "lowercase",
+        "on": "submit"
+      },
       "required": true,
       "source": {
         "field": "extendedStaffDetailsContext.linemanagerEmail"
@@ -88,6 +91,10 @@
       "label": "Delegate email",
       "hint": "Must be a homeoffice.gov.uk or digital.homeoffice.gov.uk address",
       "type": "email",
+      "format": {
+        "type": "lowercase",
+        "on": "submit"
+      },
       "required": true,
       "source": {
         "field": "extendedStaffDetailsContext.delegateEmails"

--- a/src/utils/Format/formatDataForForm.js
+++ b/src/utils/Format/formatDataForForm.js
@@ -1,0 +1,18 @@
+// Local imports
+import { formatDataForComponents } from './formatDataForComponent';
+import { formatDataForPages } from './formatDataForPage';
+
+/**
+ * Formats the data for all components on a form, according to each component's format configuration.
+ * @param {object} form The form to format the components for.
+ * @param {object} data The top-level form data.
+ * @param {string} eventType What type of event initiated this call.
+ */
+const formatDataForForm = (form, baseData, eventType) => {
+  const data = {...baseData};
+  formatDataForComponents(form.components, data, eventType);
+  formatDataForPages(form.pages, data, eventType);
+  return data;
+};
+
+export default formatDataForForm;

--- a/src/utils/Format/formatDataForForm.test.js
+++ b/src/utils/Format/formatDataForForm.test.js
@@ -1,0 +1,61 @@
+// Local imports
+import { EventTypes } from '../../models';
+import formatDataForForm from './formatDataForForm';
+
+describe('utils', () => {
+
+  describe('Format', () => {
+
+    const setupField = (fieldId, format) => {
+      return { fieldId, format };
+    };
+
+    describe('formatDataForForm', () => {
+
+      it('should appropriately format entire form', () => {
+        const EVENT_TYPE = EventTypes.SUBMIT;
+        const COMPONENTS = [
+          setupField('alpha', { type: 'lowercase', on: EventTypes.SUBMIT }), // Should be formatted
+          setupField('bravo', null), // Nothing to format
+          setupField('charlie', { type: 'uppercase', on: EventTypes.SUBMIT }), // Should be formatted
+          setupField('delta', { type: 'uppercase', on: EventTypes.BLUR }), // Should not be formatted because of event type
+          setupField('echo', { type: 'uppercase', on: EventTypes.SUBMIT }), // Should not be formatted because of event type
+          setupField('foxtrot', { type: 'lowercase', on: EventTypes.SUBMIT }), // Should not be formatted because of event type
+        ];
+        const DATA = {
+          alpha: 'AlPhA',
+          bravo: 'bRaVo',
+          charlie: 'CHArlie',
+          delta: 'deLTA',
+          foxtrot: 'FOXTROT'
+        };
+        const FORM = {
+          components: COMPONENTS.slice(0, 1),
+          pages: [
+            { components: COMPONENTS.slice(2, 3) },
+            { components: COMPONENTS.slice(4) }
+          ]
+        };
+        const FORMATTED_DATA = formatDataForForm(FORM, DATA, EVENT_TYPE);
+        expect(FORMATTED_DATA).toEqual({
+          alpha: 'alpha',
+          bravo: 'bRaVo',
+          charlie: 'CHARLIE',
+          delta: 'deLTA',
+          foxtrot: 'foxtrot'
+        });
+        // The original DATA, meanwhile, should remain untouched.
+        expect(DATA).toEqual({
+          alpha: 'AlPhA',
+          bravo: 'bRaVo',
+          charlie: 'CHArlie',
+          delta: 'deLTA',
+          foxtrot: 'FOXTROT'
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/src/utils/Format/formatDataForPage.js
+++ b/src/utils/Format/formatDataForPage.js
@@ -1,0 +1,24 @@
+// Local imports
+import { formatDataForComponents } from './formatDataForComponent';
+
+/**
+ * Formats the data for all components on a page, according to each component's format configuration.
+ * @param {object} page The page to format the components for.
+ * @param {object} data The top-level form data.
+ * @param {string} eventType What type of event initiated this call.
+ */
+const formatDataForPage = (page, data, eventType) => {
+  formatDataForComponents(page.components, data, eventType);
+};
+
+/**
+ * Formats the data for all components on a page, according to each component's format configuration.
+ * @param {Array} pages The pages to format the components for.
+ * @param {object} data The top-level form data.
+ * @param {string} eventType What type of event initiated this call.
+ */
+export const formatDataForPages = (pages, data, eventType) => {
+  pages.forEach(page => formatDataForPage(page, data, eventType));
+};
+
+export default formatDataForPage;

--- a/src/utils/Format/formatDataForPage.test.js
+++ b/src/utils/Format/formatDataForPage.test.js
@@ -1,0 +1,74 @@
+// Local imports
+import { EventTypes } from '../../models';
+import formatDataForPage, { formatDataForPages } from './formatDataForPage';
+
+describe('utils', () => {
+
+  describe('Format', () => {
+
+    const setupField = (fieldId, format) => {
+      return { fieldId, format };
+    };
+
+    describe('formatDataForPage', () => {
+
+      it('should appropriately format a page of components', () => {
+        const EVENT_TYPE = EventTypes.SUBMIT;
+        const COMPONENTS = [
+          setupField('alpha', { type: 'lowercase', on: EventTypes.SUBMIT }), // Should be formatted
+          setupField('bravo', null), // Nothing to format
+          setupField('charlie', { type: 'uppercase', on: EventTypes.SUBMIT }), // Should be formatted
+          setupField('delta', { type: 'uppercase', on: EventTypes.BLUR }), // Should not be formatted because of event type
+        ];
+        const DATA = {
+          alpha: 'AlPhA',
+          bravo: 'bRaVo',
+          charlie: 'CHArlie',
+          delta: 'deLTA'
+        };
+        const PAGE = { components: COMPONENTS };
+        formatDataForPage(PAGE, DATA, EVENT_TYPE);
+        expect(DATA).toEqual({
+          alpha: 'alpha',
+          bravo: 'bRaVo',
+          charlie: 'CHARLIE',
+          delta: 'deLTA'
+        });
+      });
+
+    });
+
+    describe('formatDataForPages', () => {
+
+      it('should appropriately format multiple pages', () => {
+        const EVENT_TYPE = EventTypes.SUBMIT;
+        const COMPONENTS = [
+          setupField('alpha', { type: 'lowercase', on: EventTypes.SUBMIT }), // Should be formatted
+          setupField('bravo', null), // Nothing to format
+          setupField('charlie', { type: 'uppercase', on: EventTypes.SUBMIT }), // Should be formatted
+          setupField('delta', { type: 'uppercase', on: EventTypes.BLUR }), // Should not be formatted because of event type
+        ];
+        const DATA = {
+          alpha: 'AlPhA',
+          bravo: 'bRaVo',
+          charlie: 'CHArlie',
+          delta: 'deLTA'
+        };
+        const PAGES = [
+          { components: COMPONENTS.slice(0, 1) },
+          { components: COMPONENTS.slice(2) }
+        ];
+        formatDataForPages(PAGES, DATA, EVENT_TYPE);
+        expect(DATA).toEqual({
+          alpha: 'alpha',
+          bravo: 'bRaVo',
+          charlie: 'CHARLIE',
+          delta: 'deLTA'
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/src/utils/Format/index.js
+++ b/src/utils/Format/index.js
@@ -1,10 +1,14 @@
 // Local imports
 import formatData from './formatData';
 import formatDataForComponent from './formatDataForComponent';
+import formatDataForForm from './formatDataForForm';
+import formatDataForPage from './formatDataForPage';
 
 const Format = {
   component: formatDataForComponent,
   data: formatData,
+  form: formatDataForForm,
+  page: formatDataForPage
 };
 
 export default Format;


### PR DESCRIPTION
### Description
Format the value of the entire form (or individual pages) for a specified event - i.e., the data can be formatted on blur, on submit, etc.

The `FormRenderer` now invokes this formatting at the point of submission.

### To test
Covered by accompanying unit tests. You can also see this by going to the Storybook stories and editing the line manager. Set it to be uppercase (or mixed case) and you will see that it formats it to lowercase on submission.