### PR TITLE
COP-9746: Add util function for determining if CYA can be submitted

### DIFF
--- a/src/components/FormRenderer/helpers/canCYASubmit.js
+++ b/src/components/FormRenderer/helpers/canCYASubmit.js
@@ -1,0 +1,21 @@
+// Local imports
+import Utils from '../../../utils';
+
+/**
+ * Assesses whether the CYA screen can submit.
+ * Presently, this will validate all of the form pages and, only if all pages are
+ * valid will it proceed.
+ * @param {Array} pages All of the pages contained within the form.
+ * @param {Function} onError A function to call with any validation errors.
+ * @returns A boolean where `true` means the CYA can submit and `false` means it cannot.
+ */
+const canCYASubmit = (pages, onError) => {
+  const errors = [];
+  pages.forEach(p => {
+    errors.push(...Utils.Validate.page(p.components, p.formData));
+  });
+  onError(errors);
+  return errors.length === 0;
+};
+
+export default canCYASubmit;

--- a/src/components/FormRenderer/helpers/canCYASubmit.test.js
+++ b/src/components/FormRenderer/helpers/canCYASubmit.test.js
@@ -1,0 +1,109 @@
+// Local imports
+import canCYASubmit from './canCYASubmit';
+
+describe('components', () => {
+
+  describe('FormRenderer', () => {
+
+    describe('helpers', () => {
+
+      describe('canCYASubmit', () => {
+
+        it('should return true when all pages are valid', () => {
+          const PAGE_1 = {
+            components: [
+              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
+            ],
+            formData: {
+              a: 'Bravo'
+            }
+          };
+          const PAGE_2 = {
+            components: [
+              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
+            ],
+            formData: {
+              c: 'Delta'
+            }
+          };
+          expect(canCYASubmit([ PAGE_1, PAGE_2 ], () => {})).toBeTruthy();
+        });
+
+        it('should return false when the first page is invalid and should have called the onErrors method appropriately', () => {
+          const PAGE_1 = {
+            components: [
+              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
+            ],
+            formData: {}
+          };
+          const PAGE_2 = {
+            components: [
+              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
+            ],
+            formData: {
+              c: 'Delta'
+            }
+          };
+          const ERRORS = [];
+          const ON_ERROR = (errors) => {
+            ERRORS.push(...errors);
+          };
+          expect(canCYASubmit([PAGE_1, PAGE_2], ON_ERROR)).toBeFalsy();
+          expect(ERRORS.length).toEqual(1);
+          expect(ERRORS[0]).toEqual({ id: 'a', error: 'Alpha is required' });
+        });
+
+        it('should return false when the second page is invalid and should have called the onErrors method appropriately', () => {
+          const PAGE_1 = {
+            components: [
+              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
+            ],
+            formData: {
+              a: 'Bravo'
+            }
+          };
+          const PAGE_2 = {
+            components: [
+              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
+            ],
+            formData: {}
+          };
+          const ERRORS = [];
+          const ON_ERROR = (errors) => {
+            ERRORS.push(...errors);
+          };
+          expect(canCYASubmit([PAGE_1, PAGE_2], ON_ERROR)).toBeFalsy();
+          expect(ERRORS.length).toEqual(1);
+          expect(ERRORS[0]).toEqual({ id: 'c', error: 'Charlie is required' });
+        });
+
+        it('should return false when the both pages are invalid and should have called the onErrors method appropriately', () => {
+          const PAGE_1 = {
+            components: [
+              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
+            ],
+            formData: {}
+          };
+          const PAGE_2 = {
+            components: [
+              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
+            ],
+            formData: {}
+          };
+          const ERRORS = [];
+          const ON_ERROR = (errors) => {
+            ERRORS.push(...errors);
+          };
+          expect(canCYASubmit([PAGE_1, PAGE_2], ON_ERROR)).toBeFalsy();
+          expect(ERRORS.length).toEqual(2);
+          expect(ERRORS[0]).toEqual({ id: 'a', error: 'Alpha is required' });
+          expect(ERRORS[1]).toEqual({ id: 'c', error: 'Charlie is required' });
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/src/components/FormRenderer/helpers/index.js
+++ b/src/components/FormRenderer/helpers/index.js
@@ -1,9 +1,11 @@
 // Local imports
 import canActionProceed from './canActionProceed';
+import canCYASubmit from './canCYASubmit';
 import getFormState from './getFormState';
 
 export const helpers = {
   canActionProceed,
-  getFormState
+  canCYASubmit,
+  getFormState,
 };
 export default helpers;


### PR DESCRIPTION
### Description
Added a utility function that iterates through a set of pages to determine if they're all valid. If so, it returns `true`; if not, it returns `false` and calls an `onError` method with the array of errors across all of the pages.


### To test
Covered by accompanying unit tests.