### PR TITLE
COP-9746: Add helper method to determine the next page

### DIFF
--- a/src/components/FormRenderer/helpers/getNextPageId.js
+++ b/src/components/FormRenderer/helpers/getNextPageId.js
@@ -1,0 +1,46 @@
+import { FormPages, FormTypes, PageAction } from '../../../models';
+
+const getNextHubPageId = (action) => {
+  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
+    return FormPages.HUB;
+  }
+  return action?.nextPageId || FormPages.HUB;
+};
+
+const getNextCYAPageId = (pages, currentPageId, action) => {
+  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
+    return undefined;
+  }
+  const nextIndex = pages.findIndex(p => p.id === currentPageId) + 1;
+  return nextIndex < pages.length ? pages[nextIndex].id : FormPages.CYA;
+};
+
+const getNextWizardPageId = (pages, currentPageId, action) => {
+  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
+    return undefined;
+  }
+  const nextIndex = pages.findIndex(p => p.id === currentPageId) + 1;
+  return nextIndex < pages.length ? pages[nextIndex].id : undefined;
+};
+
+const getNextFormPageId = (pages, action) => {
+  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
+    return undefined;
+  }
+  return pages.length > 0 ? pages[0].id : undefined;
+};
+
+const getNextPageId = (formType, pages, currentPageId, action) => {
+  switch (formType) {
+    case FormTypes.HUB:
+      return getNextHubPageId(action);
+    case FormTypes.CYA:
+      return getNextCYAPageId(pages, currentPageId, action);
+    case FormTypes.WIZARD:
+      return getNextWizardPageId(pages, currentPageId, action);
+    default:
+      return getNextFormPageId(pages, action);
+  }
+};
+
+export default getNextPageId;

--- a/src/components/FormRenderer/helpers/getNextPageId.test.js
+++ b/src/components/FormRenderer/helpers/getNextPageId.test.js
@@ -1,0 +1,109 @@
+// Local imports
+import { FormPages, FormTypes, PageAction } from '../../../models';
+import getNextPageId from './getNextPageId';
+
+describe('components', () => {
+
+  describe('FormRenderer', () => {
+
+    describe('helpers', () => {
+
+      describe('getNextPageId', () => {
+
+        const PAGES = [
+          { id: 'alpha' },
+          { id: 'bravo' }
+        ];
+
+        describe(`when the form type is '${FormTypes.HUB}'`, () => {
+          const FORM_TYPE = FormTypes.HUB;
+
+          it(`should return '${FormPages.HUB}' by default`, () => {
+            expect(getNextPageId(FORM_TYPE, PAGES)).toEqual(FormPages.HUB);
+          });
+
+          it(`should return '${FormPages.HUB}' if the action is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
+            const ACTION = PageAction.DEFAULTS.saveAndReturn;
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toEqual(FormPages.HUB);
+          });
+
+          it('should return action.nextPageId if specified', () => {
+            const ACTION = { nextPageId: 'bob' };
+            expect(getNextPageId(FORM_TYPE, PAGES, undefined, ACTION)).toEqual(ACTION.nextPageId);
+          });
+
+        });
+
+        describe(`when the form type is '${FormTypes.CYA}'`, () => {
+          const FORM_TYPE = FormTypes.CYA;
+
+          it('should return the first page by default', () => {
+            expect(getNextPageId(FORM_TYPE, PAGES)).toEqual(PAGES[0].id);
+          });
+
+          it('should return the second page when on the first page', () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id)).toEqual(PAGES[1].id);
+          });
+
+          it(`should return '${FormPages.CYA}' when on the last page`, () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[PAGES.length - 1].id)).toEqual(FormPages.CYA);
+          });
+
+          it(`should return undefined if the action is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
+            const ACTION = PageAction.DEFAULTS.saveAndReturn;
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toBeUndefined();
+          });
+
+        });
+
+        describe(`when the form type is '${FormTypes.WIZARD}'`, () => {
+          const FORM_TYPE = FormTypes.WIZARD;
+
+          it('should return the first page by default', () => {
+            expect(getNextPageId(FORM_TYPE, PAGES)).toEqual(PAGES[0].id);
+          });
+
+          it('should return the second page when on the first page', () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id)).toEqual(PAGES[1].id);
+          });
+
+          it('should return undefined when on the last page', () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[PAGES.length - 1].id)).toBeUndefined();
+          });
+
+          it(`should return undefined if the action is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
+            const ACTION = PageAction.DEFAULTS.saveAndReturn;
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toBeUndefined();
+          });
+
+        });
+
+        describe(`when the form type is '${FormTypes.FORM}'`, () => {
+          const FORM_TYPE = FormTypes.FORM;
+
+          it(`should always return the first page if there any pages and the action is not '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
+            const ACTION = { type: PageAction.TYPES.SUBMIT, nextPageId: 'bob' };
+            expect(getNextPageId(FORM_TYPE, PAGES)).toEqual(PAGES[0].id);
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id)).toEqual(PAGES[0].id);
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[1].id)).toEqual(PAGES[0].id);
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toEqual(PAGES[0].id);
+          });
+
+          it(`should return undefined if the action is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
+            const ACTION = PageAction.DEFAULTS.saveAndReturn;
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toBeUndefined();
+          });
+
+          it('should return undefined if there are no pages', () => {
+            expect(getNextPageId(FORM_TYPE, [])).toBeUndefined();
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/src/components/FormRenderer/helpers/index.js
+++ b/src/components/FormRenderer/helpers/index.js
@@ -2,10 +2,12 @@
 import canActionProceed from './canActionProceed';
 import canCYASubmit from './canCYASubmit';
 import getFormState from './getFormState';
+import getNextPageId from './getNextPageId';
 
 export const helpers = {
   canActionProceed,
   canCYASubmit,
   getFormState,
+  getNextPageId
 };
 export default helpers;

--- a/src/models/FormPages.js
+++ b/src/models/FormPages.js
@@ -1,0 +1,9 @@
+const PAGE_CYA = 'cya';
+const PAGE_HUB = 'hub';
+
+const FormPages = {
+  CYA: PAGE_CYA,
+  HUB: PAGE_HUB
+};
+
+export default FormPages;

--- a/src/models/PageAction.js
+++ b/src/models/PageAction.js
@@ -1,0 +1,22 @@
+const TYPE_SUBMIT = 'submit';
+const TYPE_SAVE_AND_CONTINUE = 'saveAndContinue';
+const TYPE_SAVE_AND_RETURN = 'saveAndReturn';
+
+export const PageActionTypes = {
+  SUBMIT: TYPE_SUBMIT,
+  SAVE_AND_CONTINUE: TYPE_SAVE_AND_CONTINUE,
+  SAVE_AND_RETURN: TYPE_SAVE_AND_RETURN
+};
+
+export const DefaultPageActions = {
+  [TYPE_SUBMIT]: { type: TYPE_SUBMIT, validate: true },
+  [TYPE_SAVE_AND_CONTINUE]: { type: TYPE_SAVE_AND_CONTINUE, validate: true, label: 'Save and continue' },
+  [TYPE_SAVE_AND_RETURN]: { type: TYPE_SAVE_AND_RETURN, validate: false, label: 'Save and return later', classModifiers: 'secondary' }
+};
+
+const PageAction = {
+  TYPES: PageActionTypes,
+  DEFAULTS: DefaultPageActions
+};
+
+export default PageAction;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,12 +1,16 @@
 // Local imports
 import ComponentTypes from './ComponentTypes';
 import EventTypes from './EventTypes';
+import FormPages from './FormPages';
 import FormTypes from './FormTypes';
 import HubFormats from './HubFormats';
+import PageAction from './PageAction';
 
 export {
   ComponentTypes,
   EventTypes,
+  FormPages,
   FormTypes,
-  HubFormats
+  HubFormats,
+  PageAction
 };


### PR DESCRIPTION
### Description
Added a helper method to determine what should be the next page, depending on the type of form being rendered, the current page, and which action has just been invoked (if any). Also added two new types to support this functionality.

### To test
Covered by the accompanying unit tests.