### PR TITLE
COP-9746: Support additional action button types

### DIFF
--- a/src/components/FormPage/FormPage.test.js
+++ b/src/components/FormPage/FormPage.test.js
@@ -3,7 +3,8 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 // Local imports
-import { DEFAULT_ACTIONS, DEFAULT_LABEL } from '../PageActions/ActionButton';
+import { PageAction } from '../../models';
+import { DEFAULT_LABEL } from '../PageActions/ActionButton';
 import FormPage, { DEFAULT_CLASS } from './FormPage';
 
 describe('components', () => {
@@ -101,7 +102,7 @@ describe('components', () => {
       // And confirm an appropriate action was received.
       expect(ON_ACTION_CALLS.length).toEqual(1);
       expect(PAGE.formData.text).toEqual(NEW_VALUE);
-      expect(ON_ACTION_CALLS[0].action).toEqual(DEFAULT_ACTIONS.submit);
+      expect(ON_ACTION_CALLS[0].action).toEqual(PageAction.DEFAULTS.submit);
       expect(ON_ACTION_CALLS[0].patch).toEqual({ text: NEW_VALUE });
     });
 

--- a/src/components/PageActions/ActionButton.jsx
+++ b/src/components/PageActions/ActionButton.jsx
@@ -3,21 +3,26 @@ import { Button } from '@ukhomeoffice/cop-react-components';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+// Local imports
+import { PageAction } from '../../models';
+
 export const DEFAULT_LABEL = 'Continue';
-export const DEFAULT_ACTIONS = {
-  submit: { type: 'submit', validate: true }
-};
 const ActionButton = ({
   action: _action,
   onAction,
   ...attrs
 }) => {
-  const action = typeof(_action) === 'string' ? DEFAULT_ACTIONS[_action] : _action;
+  const action = typeof(_action) === 'string' ? PageAction.DEFAULTS[_action] : _action;
   if (!action) {
     return null;
   }
   return (
-    <Button {...attrs} className={action.className} classModifiers={action.classModifiers} onClick={() => onAction(action)}>
+    <Button
+      {...attrs}
+      className={action.className}
+      classModifiers={action.classModifiers}
+      start={action.start || false}
+      onClick={() => onAction(action)}>
       {action.label || DEFAULT_LABEL}
     </Button>
   );

--- a/src/components/PageActions/ActionButton.jsx
+++ b/src/components/PageActions/ActionButton.jsx
@@ -22,7 +22,8 @@ const ActionButton = ({
       className={action.className}
       classModifiers={action.classModifiers}
       start={action.start || false}
-      onClick={() => onAction(action)}>
+      onClick={() => onAction(action)}
+    >
       {action.label || DEFAULT_LABEL}
     </Button>
   );

--- a/src/components/PageActions/ActionButton.test.js
+++ b/src/components/PageActions/ActionButton.test.js
@@ -3,7 +3,8 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 // Local imports
-import ActionButton, { DEFAULT_ACTIONS, DEFAULT_LABEL } from './ActionButton';
+import { PageAction } from '../../models';
+import ActionButton, { DEFAULT_LABEL } from './ActionButton';
 
 describe('components', () => {
 
@@ -37,7 +38,7 @@ describe('components', () => {
       // Click the button and make sure it fires the onAction handler.
       fireEvent.click(button, {});
       expect(ON_ACTION_CALLS.length).toEqual(1);
-      expect(ON_ACTION_CALLS[0]).toEqual(DEFAULT_ACTIONS.submit);
+      expect(ON_ACTION_CALLS[0]).toEqual(PageAction.DEFAULTS.submit);
     });
 
     it('should appropriately display a custom action', async () => {

--- a/src/components/PageActions/PageActions.test.js
+++ b/src/components/PageActions/PageActions.test.js
@@ -3,7 +3,8 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 // Local imports
-import { DEFAULT_ACTIONS, DEFAULT_LABEL } from './ActionButton';
+import { PageAction } from '../../models';
+import { DEFAULT_LABEL } from './ActionButton';
 import PageActions from './PageActions';
 
 describe('components', () => {
@@ -41,7 +42,7 @@ describe('components', () => {
       // Click the button and make sure it fires the onAction handler.
       fireEvent.click(submit, {});
       expect(ON_ACTION_CALLS.length).toEqual(1);
-      expect(ON_ACTION_CALLS[0]).toEqual(DEFAULT_ACTIONS.submit);
+      expect(ON_ACTION_CALLS[0]).toEqual(PageAction.DEFAULTS.submit);
     });
 
     it('should appropriately display a custom action', async () => {
@@ -84,7 +85,7 @@ describe('components', () => {
       fireEvent.click(submit, {});
       expect(ON_ACTION_CALLS.length).toEqual(2);
       expect(ON_ACTION_CALLS[0]).toEqual(NAVIGATE);
-      expect(ON_ACTION_CALLS[1]).toEqual(DEFAULT_ACTIONS.submit);
+      expect(ON_ACTION_CALLS[1]).toEqual(PageAction.DEFAULTS.submit);
     });
 
   });


### PR DESCRIPTION
### Description
Adjusted the logic around the `ActionButton` component to support additional types, such as a start button, and leverage `PageAction` logic recently added.

### To test
The accompanying unit tests have been updated.