### PR TITLE
COP-9746: Add onFormComplete hook

### DIFF
--- a/src/hooks/useHooks.js
+++ b/src/hooks/useHooks.js
@@ -1,18 +1,20 @@
-export const ALLOWED_HOOKS = ['onRequest', 'onFormLoad', 'onPageChange', 'onSubmit'];
+export const ALLOWED_HOOKS = ['onRequest', 'onFormComplete', 'onFormLoad', 'onPageChange', 'onSubmit'];
 
 const DEFAULT_HOOKS = {
-  onRequest: (req) => req,
+  onFormComplete: () => {},
   onFormLoad: () => {},
   onPageChange: (pageId) => pageId,
+  onRequest: (req) => req,
   onSubmit: (type, payload, onSuccess, onError) => {
     if (typeof onSuccess === 'function') onSuccess();
   }
 };
 
 const hooks = {
-  onRequest: DEFAULT_HOOKS.onRequest,
+  onFormComplete: DEFAULT_HOOKS.onFormComplete,
   onFormLoad: DEFAULT_HOOKS.onFormLoad,
   onPageChange: DEFAULT_HOOKS.onPageChange,
+  onRequest: DEFAULT_HOOKS.onRequest,
   onSubmit: DEFAULT_HOOKS.onSubmit
 };
 


### PR DESCRIPTION
### Description
Added a hook for when the form is complete. It's expected that this will only fire on a "Check your answers" form as it's the only one with a genuine end state - the other form types will have appropriate completion actions on their page(s).

### To test
The unit tests already cover the functionality for changing the hook and this PR doesn't include _use_ of the hook - that will be covered elsewhere.