### PR TITLE
COP-9746: Refactor FormState logic

### DIFF
--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -85,8 +85,7 @@ const FormRenderer = ({
         handlers.navigate(action, pageId, onPageChange);
       } else {
         // Submit.
-        const rawData = patch ? { ...data, ...patch } : { ...data };
-        const submissionData = Utils.Format.form({ pages, components }, rawData, EventTypes.SUBMIT);
+        const submissionData = Utils.Format.form({ pages, components }, { ...data, ...patch }, EventTypes.SUBMIT);
         if (patch) {
           setData(submissionData);
         }

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 
 // Local imports
 import { useHooks } from '../../hooks';
-import { EventTypes, FormTypes } from '../../models';
+import { EventTypes, FormPages, FormTypes } from '../../models';
 import Utils from '../../utils';
 import CheckYourAnswers from '../CheckYourAnswers';
 import FormPage from '../FormPage';
@@ -33,7 +33,7 @@ const FormRenderer = ({
   const [data, setData] = useState({});
   const [pages, setPages] = useState([]);
   const [hub, setHub] = useState(undefined);
-  const [pageId, setPageId] = useState('hub');
+  const [pageId, setPageId] = useState(helpers.getNextPageId(type, _pages));
   const [formState, setFormState] = useState(helpers.getFormState(pageId, pages, hub));
   
   // Set up hooks.
@@ -77,7 +77,7 @@ const FormRenderer = ({
   };
 
   // Handle actions from pages.
-  const onAction = (action, patch, onError) => {
+  const onPageAction = (action, patch, onError) => {
     // Check to see whether the action is able to proceed, which in
     // in the case of a submission will validate the fields in the page.
     if (helpers.canActionProceed(action, formState.page, onError)) {
@@ -92,7 +92,8 @@ const FormRenderer = ({
         }
         // Now submit the data to the backend...
         hooks.onSubmit(action.type, submissionData, () => {
-          onPageChange('hub');
+          const nextPageId = helpers.getNextPageId(type, pages, pageId, action);
+          onPageChange(nextPageId);
         }, (errors) => {
           handlers.submissionError(errors, onError);
         });
@@ -108,9 +109,9 @@ const FormRenderer = ({
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
     <div className={classes()}>
-      {title && pageId === 'hub' && <LargeHeading>{title}</LargeHeading>}
       {formState.cya && <CheckYourAnswers pages={pages} {...cya} {...formState.cya} onAction={onCYAAction} />}
-      {formState.page && <FormPage page={formState.page} onAction={onAction} />}
+      {title && pageId === FormPages.HUB && <LargeHeading>{title}</LargeHeading>}
+      {formState.page && <FormPage page={formState.page} onAction={onPageAction} />}
     </div>
   );
 };

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -109,8 +109,8 @@ const FormRenderer = ({
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
     <div className={classes()}>
-      {formState.cya && <CheckYourAnswers pages={pages} {...cya} {...formState.cya} onAction={onCYAAction} />}
       {title && pageId === FormPages.HUB && <LargeHeading>{title}</LargeHeading>}
+      {formState.cya && <CheckYourAnswers pages={pages} {...cya} {...formState.cya} onAction={onCYAAction} />}
       {formState.page && <FormPage page={formState.page} onAction={onPageAction} />}
     </div>
   );

--- a/src/components/FormRenderer/helpers/getCYA.js
+++ b/src/components/FormRenderer/helpers/getCYA.js
@@ -1,5 +1,5 @@
 // Local imports
-import { HubFormats } from '../../../models';
+import { FormPages, HubFormats } from '../../../models';
 
 /**
  * Gets a configuration object for the Check your answers screen.
@@ -8,9 +8,9 @@ import { HubFormats } from '../../../models';
  * @returns A configuration object for the Check your answers screen.
  */
 const getCYA = (pageId, hub) => {
-  if (pageId === 'hub' && hub === HubFormats.CYA) {
+  if (pageId === FormPages.HUB && hub === HubFormats.CYA) {
     return { title: '' };
-  } else if (pageId === HubFormats.CYA) {
+  } else if (pageId === FormPages.CYA) {
     return {};
   }
   return undefined;

--- a/src/components/FormRenderer/helpers/getCYA.test.js
+++ b/src/components/FormRenderer/helpers/getCYA.test.js
@@ -1,5 +1,5 @@
 // Local imports
-import { HubFormats } from '../../../models';
+import { FormPages, HubFormats } from '../../../models';
 import getCYA from './getCYA';
 
 describe('components', () => {
@@ -7,24 +7,24 @@ describe('components', () => {
   describe('FormRenderer', () => {
 
     describe('helpers', () => {
-      const HUB = { id: 'hub', components: [] };
+      const HUB = { id: FormPages.HUB, components: [] };
 
       describe('getCYA', () => {
 
         it('should give an empty object if the pageId is "CYA"', () => {
-          expect(getCYA(HubFormats.CYA)).toEqual({});
+          expect(getCYA(FormPages.CYA)).toEqual({});
         });
 
         it('should give an object with a blank title if the pageId is "hub" and the hub is the CYA', () => {
-          expect(getCYA('hub', HubFormats.CYA)).toEqual({ title: '' });
+          expect(getCYA(FormPages.HUB, HubFormats.CYA)).toEqual({ title: '' });
         });
 
         it('should give undefined if pageId is "hub" and the hub is NOT the CYA', () => {
-          expect(getCYA('hub', HUB)).toBeUndefined();
+          expect(getCYA(FormPages.HUB, HUB)).toBeUndefined();
         });
 
         it('should give undefined if pageId is NOT "hub" and the hub is NOT the CYA', () => {
-          expect(getCYA('bob', HUB)).toBeUndefined();
+          expect(getCYA(FormPages.HUB, HUB)).toBeUndefined();
         });
 
         it('should give undefined if pageId is NOT "hub" and the hub is the CYA', () => {

--- a/src/components/FormRenderer/helpers/getFormState.test.js
+++ b/src/components/FormRenderer/helpers/getFormState.test.js
@@ -1,5 +1,5 @@
 // Local imports
-import { HubFormats } from '../../../models';
+import { FormPages, HubFormats } from '../../../models';
 import getFormState from './getFormState';
 
 describe('components', () => {
@@ -7,7 +7,7 @@ describe('components', () => {
   describe('FormRenderer', () => {
 
     describe('helpers', () => {
-      const HUB = { id: 'hub', components: [] };
+      const HUB = { id: FormPages.HUB, components: [] };
       const PAGES = [
         { id: 'alpha', components: ['x'] },
         { id: 'bravo', components: ['y', 'z'] },
@@ -17,24 +17,24 @@ describe('components', () => {
       describe('getFormState', () => {
 
         it('should set up accordingly when viewing a hub that is the CYA', () => {
-          expect(getFormState('hub', PAGES, HubFormats.CYA)).toEqual({
-            pageId: 'hub',
+          expect(getFormState(FormPages.HUB, PAGES, HubFormats.CYA)).toEqual({
+            pageId: FormPages.HUB,
             cya: { title: '' },
             page: undefined
           });
         });
 
         it('should set up accordingly when viewing a hub that is NOT the CYA', () => {
-          expect(getFormState('hub', PAGES, HUB)).toEqual({
-            pageId: 'hub',
+          expect(getFormState(FormPages.HUB, PAGES, HUB)).toEqual({
+            pageId: FormPages.HUB,
             cya: undefined,
             page: HUB
           });
         });
 
         it('should set up accordingly when viewing the CYA', () => {
-          expect(getFormState(HubFormats.CYA, PAGES, HUB)).toEqual({
-            pageId: HubFormats.CYA,
+          expect(getFormState(FormPages.CYA, PAGES, HUB)).toEqual({
+            pageId: FormPages.CYA,
             cya: {},
             page: undefined
           });

--- a/src/components/FormRenderer/helpers/getPage.js
+++ b/src/components/FormRenderer/helpers/getPage.js
@@ -1,5 +1,5 @@
 // Local imports
-import { HubFormats } from '../../../models';
+import { FormPages, HubFormats } from '../../../models';
 
 /**
  * Gets the current page to render, which may be undefined if the current page is the "hub".
@@ -10,7 +10,7 @@ import { HubFormats } from '../../../models';
  */
 const getPage = (pageId, pages, hub) => {
   if (pageId) {
-    if (pageId === 'hub') {
+    if (pageId === FormPages.HUB) {
       return hub === HubFormats.CYA ? undefined : hub;
     }
     return pages.find(p => p.id === pageId);

--- a/src/components/FormRenderer/helpers/getPage.test.js
+++ b/src/components/FormRenderer/helpers/getPage.test.js
@@ -1,5 +1,5 @@
 // Local imports
-import { HubFormats } from '../../../models';
+import { FormPages, HubFormats } from '../../../models';
 import getPage from './getPage';
 
 describe('components', () => {
@@ -7,7 +7,7 @@ describe('components', () => {
   describe('FormRenderer', () => {
 
     describe('helpers', () => {
-      const HUB = { id: 'hub', components: [] };
+      const HUB = { id: FormPages.HUB, components: [] };
       const PAGES = [
         { id: 'alpha', components: ['x'] },
         { id: 'bravo', components: ['y', 'z'] },
@@ -21,11 +21,11 @@ describe('components', () => {
         });
 
         it('should give undefined if the pageId is "hub" but the hub is the CYA', () => {
-          expect(getPage('hub', PAGES, HubFormats.CYA)).toBeUndefined();
+          expect(getPage(FormPages.HUB, PAGES, HubFormats.CYA)).toBeUndefined();
         });
 
         it('should give hub if the pageId is "hub" and the hub is NOT the CYA', () => {
-          expect(getPage('hub', PAGES, HUB)).toEqual(HUB);
+          expect(getPage(FormPages.HUB, PAGES, HUB)).toEqual(HUB);
         });
 
         it('should give find the appropriate page if the pageId is not "hub"', () => {


### PR DESCRIPTION
### Description
Use the new `FormPages` model, getting rid of hard-coded `'hub'` values and incorrect use of `HubFormats` for page ids.

### To test
Covered by the accompanying unit test changes.