### PR TITLE
COP-9746: Allow custom actions for Check your answers

### DIFF
--- a/src/components/CheckYourAnswers/CheckYourAnswers.jsx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useEffect, useState } from 'react';
 
 // Local imports
-import { PageAction } from '../../models';
 import Utils from '../../utils';
 import PageActions from '../PageActions';
 import SummaryList from '../SummaryList';
@@ -19,6 +18,7 @@ export const DEFAULT_MARGIN_BOTTOM = 9;
 const CheckYourAnswers = ({
   title,
   pages: _pages,
+  actions,
   onAction,
   onRowAction,
   hide_page_titles,
@@ -65,7 +65,7 @@ const CheckYourAnswers = ({
           </Fragment>
         );
       })}
-      {!hide_actions && <PageActions actions={[PageAction.TYPES.SUBMIT]} onAction={(action) => onAction(action, onError)} />}
+      {!hide_actions && <PageActions actions={actions} onAction={(action) => onAction(action, onError)} />}
     </div>
   )
 };
@@ -73,6 +73,7 @@ const CheckYourAnswers = ({
 CheckYourAnswers.propTypes = {
   title: PropTypes.string.isRequired,
   pages: PropTypes.arrayOf(PropTypes.object).isRequired,
+  actions: PropTypes.arrayOf(PropTypes.object),
   onAction: PropTypes.func.isRequired,
   onRowAction: PropTypes.func.isRequired,
   hide_page_titles: PropTypes.bool,

--- a/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
@@ -13,6 +13,7 @@ import GRADE from '../../json/grade.json';
 import TEAMS from '../../json/team.json';
 import USER_PROFILE_DATA from '../../json/userProfile.data.json';
 import USER_PROFILE from '../../json/userProfile.json';
+import FIRST_FORM from '../../json/firstForm.json';
 
 <Meta title="Components/Check your answers" id="D-CheckYourAnswers" component={ CheckYourAnswers } decorators={[withMock]} />
 
@@ -44,13 +45,16 @@ Renders the **Check your answers** screen for a form.
     ]
   }}>
     {() => {
-      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA)
+      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA);
       const PAGES = Utils.FormPage.getAll(USER_PROFILE.pages, USER_PROFILE.components, { ...DATA });
       const ON_ACTION = (action, patch, onError) => {
         console.log('action invoked', action, patch);
       };
+      const ON_ROW_ACTION = (page) => {
+        console.log('row action invoked', page);
+      };
       return (
-        <CheckYourAnswers pages={PAGES} onAction={ON_ACTION} />
+        <CheckYourAnswers pages={PAGES} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
       );
     }}
   </Story>
@@ -87,13 +91,58 @@ Renders the **Check your answers** screen for a form.
     ]
   }}>
     {() => {
-      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA)
+      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA);
       const PAGES = Utils.FormPage.getAll(USER_PROFILE.pages, USER_PROFILE.components, { ...DATA });
       const ON_ACTION = (action, patch, onError) => {
         console.log('action invoked', action, patch);
       };
+      const ON_ROW_ACTION = (page) => {
+        console.log('row action invoked', page);
+      };
       return (
-        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} />
+        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### With actions
+
+<Canvas>
+  <Story name="With actions" parameters={{
+    mockData: [
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+        method: 'GET',
+        status: 200,
+        response: CIVIL_SERVANT
+      },
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+        method: 'GET',
+        status: 200,
+        response: GRADE
+      },
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/team`,
+        method: 'GET',
+        status: 200,
+        response: TEAMS
+      }
+    ]
+  }}>
+    {() => {
+      const DATA = { firstName: 'John', surname: 'Smith', age: 41 };
+      const PAGES = Utils.FormPage.getAll(FIRST_FORM.pages, FIRST_FORM.components, { ...DATA });
+      const ACTIONS = FIRST_FORM.cya.actions;
+      const ON_ACTION = (action, patch, onError) => {
+        console.log('action invoked', action, patch);
+      };
+      const ON_ROW_ACTION = (page) => {
+        console.log('row action invoked', page);
+      };
+      return (
+        <CheckYourAnswers pages={PAGES} hide_page_titles={true} actions={ACTIONS} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
       );
     }}
   </Story>

--- a/src/json/firstForm.json
+++ b/src/json/firstForm.json
@@ -42,7 +42,7 @@
         "If you are happy to proceed, click start now."
       ],
       "actions": [
-        { "type": "start", "start": true, "label": "Start now" }
+        { "type": "navigate", "url": "/firstName", "start": true, "label": "Start now" }
       ],
       "show_on_cya": false
     },
@@ -86,5 +86,9 @@
       }
     }
   ],
-  "cya": {}
+  "cya": {
+    "actions": [
+      { "type": "submit", "label": "Submit", "validate": true }
+    ]
+  }
 }


### PR DESCRIPTION
### Description
Rather than simply offering a generic "Submit" on the **Check your answers** screen, allow custom actions from the JSON, just like any other page.

### To test
The `cya` object in the JSON can contain an `actions` property, which will dictate which buttons (if any) get shown at the bottom of the **Check your answers** screen. If there is no `actions` property (or it is an empty array), no buttons should be shown.