### PR TITLE
EAB-85 Add date component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -7,6 +7,7 @@ const TYPE_PHONE_NUMBER = 'phone-number';
 const TYPE_RADIOS = 'radios';
 const TYPE_TEXT = 'text';
 const TYPE_TEXT_AREA = 'textarea';
+const TYPE_DATE = 'date';
 
 const ComponentTypes = {
   AUTOCOMPLETE: TYPE_AUTOCOMPLETE,
@@ -17,7 +18,8 @@ const ComponentTypes = {
   PHONE_NUMBER: TYPE_PHONE_NUMBER,
   RADIOS: TYPE_RADIOS,
   TEXT: TYPE_TEXT,
-  TEXT_AREA: TYPE_TEXT_AREA
+  TEXT_AREA: TYPE_TEXT_AREA,
+  DATE: TYPE_DATE,
 };
 
 export default ComponentTypes;

--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -1,6 +1,6 @@
 const TYPE_AUTOCOMPLETE = 'autocomplete';
-const TYPE_EMAIL = 'email';
 const TYPE_DATE = 'date';
+const TYPE_EMAIL = 'email';
 const TYPE_HEADING = 'heading';
 const TYPE_HTML = 'html';
 const TYPE_INSET_TEXT = 'inset-text';

--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -1,5 +1,6 @@
 const TYPE_AUTOCOMPLETE = 'autocomplete';
 const TYPE_EMAIL = 'email';
+const TYPE_DATE = 'date';
 const TYPE_HEADING = 'heading';
 const TYPE_HTML = 'html';
 const TYPE_INSET_TEXT = 'inset-text';
@@ -7,10 +8,10 @@ const TYPE_PHONE_NUMBER = 'phone-number';
 const TYPE_RADIOS = 'radios';
 const TYPE_TEXT = 'text';
 const TYPE_TEXT_AREA = 'textarea';
-const TYPE_DATE = 'date';
 
 const ComponentTypes = {
   AUTOCOMPLETE: TYPE_AUTOCOMPLETE,
+  DATE: TYPE_DATE,
   EMAIL: TYPE_EMAIL,
   HEADING: TYPE_HEADING,
   HTML: TYPE_HTML,
@@ -19,7 +20,6 @@ const ComponentTypes = {
   RADIOS: TYPE_RADIOS,
   TEXT: TYPE_TEXT,
   TEXT_AREA: TYPE_TEXT_AREA,
-  DATE: TYPE_DATE,
 };
 
 export default ComponentTypes;

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -1,6 +1,6 @@
 // Global imports
 import React from 'react';
-import { Autocomplete, Heading, InsetText, Markup, Radios, TextArea, TextInput, DateInput } from '@ukhomeoffice/cop-react-components';
+import { Autocomplete, DateInput, Heading, InsetText, Markup, Radios, TextArea, TextInput } from '@ukhomeoffice/cop-react-components';
 
 // Local imports
 import cleanAttributes from './cleanAttributes';
@@ -20,6 +20,11 @@ const getAutocomplete = (config) => {
   const attrs = cleanAttributes(config);
   const source = Data.getAutocompleteSource(config);
   return <Autocomplete {...attrs} source={source} />;
+};
+
+const getDate = (config) => {
+  const attrs = cleanAttributes(config);
+  return <DateInput {...attrs} />;
 };
 
 const getHeading = (config) => {
@@ -54,11 +59,6 @@ const getTextArea = (config) => {
 const getTextInput = (config) => {
   const attrs = cleanAttributes(config);
   return <TextInput {...attrs} />;
-};
-
-const getDate = (config) => {
-  const attrs = cleanAttributes(config);
-  return <DateInput {...attrs} />;
 };
 
 const getComponentByType = (config) => {

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -1,6 +1,6 @@
 // Global imports
 import React from 'react';
-import { Autocomplete, Heading, InsetText, Markup, Radios, TextArea, TextInput } from '@ukhomeoffice/cop-react-components';
+import { Autocomplete, Heading, InsetText, Markup, Radios, TextArea, TextInput, DateInput } from '@ukhomeoffice/cop-react-components';
 
 // Local imports
 import cleanAttributes from './cleanAttributes';
@@ -29,7 +29,7 @@ const getHeading = (config) => {
 
 const getHTML = (config) => {
   const attrs = cleanAttributes(config);
-  return <Markup {...attrs} />
+  return <Markup {...attrs} />;
 };
 
 const getInsetText = (config) => {
@@ -56,6 +56,11 @@ const getTextInput = (config) => {
   return <TextInput {...attrs} />;
 };
 
+const getDate = (config) => {
+  const attrs = cleanAttributes(config);
+  return <DateInput {...attrs} />;
+};
+
 const getComponentByType = (config) => {
   switch (config.type) {
     case ComponentTypes.HTML:
@@ -74,6 +79,8 @@ const getComponentByType = (config) => {
       return getAutocomplete(config);
     case ComponentTypes.RADIOS:
       return getRadios(config);
+    case ComponentTypes.DATE:
+      return getDate(config);
     default: {
       return null;
     }

--- a/src/utils/Component/getComponent.test.js
+++ b/src/utils/Component/getComponent.test.js
@@ -289,6 +289,63 @@ describe('utils', () => {
       expect(textarea.id).toEqual(ID);
     });
 
+    it('should return an appropriately rendered date component', () => {
+      const ID = 'test-id';
+      const FIELD_ID = 'field-id';
+      const LABEL = 'label';
+      const COMPONENT = {
+        type: ComponentTypes.DATE,
+        id: ID,
+        fieldId: FIELD_ID,
+        label: LABEL,
+        'data-testid': ID
+      };
+      const { container } = render(getComponent(COMPONENT));
+
+      const [ formGroup, dateinput ] = getAllByTestId(container, ID);
+      expect(formGroup.tagName).toEqual('DIV');
+      expect(formGroup.classList).toContain('govuk-form-group');
+      const label = formGroup.childNodes[0];
+      expect(label.innerHTML).toContain(LABEL);
+      expect(label.getAttribute('for')).toEqual(ID);
+      expect(dateinput.tagName).toEqual('DIV');
+      expect(dateinput.classList).toContain('govuk-date-input');
+      expect(dateinput.id).toEqual(ID);
+
+      const dayitem = dateinput.childNodes[0];
+      expect(dayitem.tagName).toEqual('DIV');
+      expect(dayitem.classList).toContain('govuk-date-input__item');
+      const daylabel = dayitem.childNodes[0];
+      expect(daylabel.tagName).toEqual('LABEL');
+      expect(daylabel.classList).toContain('govuk-date-input__label');
+      expect(daylabel.textContent).toEqual('Day');
+      const dayinput = dayitem.childNodes[1];
+      expect(dayinput.tagName).toEqual('INPUT');
+      expect(dayinput.id).toEqual(`${ID}-day`);
+
+      const monthitem = dateinput.childNodes[1];
+      expect(monthitem.tagName).toEqual('DIV');
+      expect(monthitem.classList).toContain('govuk-date-input__item');
+      const monthlabel = monthitem.childNodes[0];
+      expect(monthlabel.tagName).toEqual('LABEL');
+      expect(monthlabel.classList).toContain('govuk-date-input__label');
+      expect(monthlabel.textContent).toEqual('Month');
+      const monthinput = monthitem.childNodes[1];
+      expect(monthinput.tagName).toEqual('INPUT');
+      expect(monthinput.id).toEqual(`${ID}-month`);
+
+      const yearitem = dateinput.childNodes[2];
+      expect(yearitem.tagName).toEqual('DIV');
+      expect(yearitem.classList).toContain('govuk-date-input__item');
+      const yearlabel = yearitem.childNodes[0];
+      expect(yearlabel.tagName).toEqual('LABEL');
+      expect(yearlabel.classList).toContain('govuk-date-input__label');
+      expect(yearlabel.textContent).toEqual('Year');
+      const yearinput = yearitem.childNodes[1];
+      expect(yearinput.tagName).toEqual('INPUT');
+      expect(yearinput.id).toEqual(`${ID}-year`);
+    });
+
   });
 
 });

--- a/src/utils/Component/isEditable.js
+++ b/src/utils/Component/isEditable.js
@@ -3,12 +3,12 @@ import { ComponentTypes } from '../../models';
 
 export const EDITABLE_TYPES = [
   ComponentTypes.AUTOCOMPLETE,
+  ComponentTypes.DATE,
   ComponentTypes.EMAIL,
   ComponentTypes.PHONE_NUMBER,
   ComponentTypes.RADIOS,
   ComponentTypes.TEXT,
-  ComponentTypes.TEXT_AREA,
-  ComponentTypes.DATE
+  ComponentTypes.TEXT_AREA
 ];
 
 const isEditable = (options) => {

--- a/src/utils/Component/isEditable.js
+++ b/src/utils/Component/isEditable.js
@@ -7,7 +7,8 @@ export const EDITABLE_TYPES = [
   ComponentTypes.PHONE_NUMBER,
   ComponentTypes.RADIOS,
   ComponentTypes.TEXT,
-  ComponentTypes.TEXT_AREA
+  ComponentTypes.TEXT_AREA,
+  ComponentTypes.DATE
 ];
 
 const isEditable = (options) => {


### PR DESCRIPTION
**Description**
Add support for DateInput components, which is now available in the COP React Components library.

**To test**
A unit test has been added to make sure the component is appropriately rendered from a JSON snippet. In addition, it's testable within the Storybook Sandbox.