### PR TITLE
COP-10035: Refactor actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "1.2.1",
+  "version": "2.0.0-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/json dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "^0.8.1",
+    "@ukhomeoffice/cop-react-components": "^0.8.2",
     "axios": "^0.21.1",
     "govuk-frontend": "^3.13.0",
     "web-vitals": "^1.0.1"

--- a/src/components/FormRenderer/handlers/getPageId.js
+++ b/src/components/FormRenderer/handlers/getPageId.js
@@ -5,15 +5,7 @@
  * @returns A page id.
  */
 const getPageId = (action, pageId) => {
-  if (action) {
-    // TODO: Improve how this is handled.
-    if (action.href) {
-      return action.href.split('/').pop();
-    } else if (action.url) {
-      return action.url.split('/').pop();
-    }
-  }
-  return pageId;
+  return action?.page || pageId;
 };
 
 export default getPageId;

--- a/src/components/FormRenderer/handlers/getPageId.test.js
+++ b/src/components/FormRenderer/handlers/getPageId.test.js
@@ -15,40 +15,17 @@ describe('components', () => {
           expect(getPageId(ACTION, PAGE_ID)).toEqual(PAGE_ID);
         });
 
-        it('should return the pageId when the action contains no href or url', () => {
+        it('should return the pageId when the action contains no page', () => {
           const PAGE_ID = 'alpha';
           const ACTION = { id: 'bravo' };
           expect(getPageId(ACTION, PAGE_ID)).toEqual(PAGE_ID);
         });
 
-        it('should return the final part of the href when provided', () => {
-          const LAST_PART = 'delta';
-          const HREF = `/bravo/charlie/${LAST_PART}`
+        it('should return the page when provided', () => {
+          const NAVIGATE_TO = 'delta'
           const PAGE_ID = 'alpha';
-          const ACTION = { href: HREF };
-          expect(getPageId(ACTION, PAGE_ID)).toEqual(LAST_PART);
-        });
-
-        it('should return the final part of the url when provided', () => {
-          const LAST_PART = 'delta';
-          const URL = `/bravo/charlie/${LAST_PART}`
-          const PAGE_ID = 'alpha';
-          const ACTION = { url: URL };
-          expect(getPageId(ACTION, PAGE_ID)).toEqual(LAST_PART);
-        });
-
-        it('should return the whole href when it contains no backslashes', () => {
-          const HREF = 'delta';
-          const PAGE_ID = 'alpha';
-          const ACTION = { href: HREF };
-          expect(getPageId(ACTION, PAGE_ID)).toEqual(HREF);
-        });
-
-        it('should return the whole url when it contains no backslashes', () => {
-          const URL = 'delta';
-          const PAGE_ID = 'alpha';
-          const ACTION = { url: URL };
-          expect(getPageId(ACTION, PAGE_ID)).toEqual(URL);
+          const ACTION = { page: NAVIGATE_TO };
+          expect(getPageId(ACTION, PAGE_ID)).toEqual(NAVIGATE_TO);
         });
 
       });

--- a/src/components/FormRenderer/handlers/handlers.test.js
+++ b/src/components/FormRenderer/handlers/handlers.test.js
@@ -39,7 +39,7 @@ describe('components', () => {
 
         it('should not call the onNavigate method when the page is unchanged', () => {
           const CURRENT_PAGE_ID = 'alpha';
-          const ACTION = { href: `/${CURRENT_PAGE_ID}` };
+          const ACTION = { page: CURRENT_PAGE_ID };
           const ON_NAVIGATE_CALLS = [];
           const ON_NAVIGATE = (pageId) => {
             ON_NAVIGATE_CALLS.push(pageId);
@@ -51,7 +51,7 @@ describe('components', () => {
         it('should call the onNavigate method when the page has changed', () => {
           const CURRENT_PAGE_ID = 'alpha';
           const NEW_PAGE_ID = 'bravo';
-          const ACTION = { href: `/${NEW_PAGE_ID}` };
+          const ACTION = { page: NEW_PAGE_ID };
           const ON_NAVIGATE_CALLS = [];
           const ON_NAVIGATE = (pageId) => {
             ON_NAVIGATE_CALLS.push(pageId);

--- a/src/components/PageActions/PageActions.stories.mdx
+++ b/src/components/PageActions/PageActions.stories.mdx
@@ -43,7 +43,7 @@ Renders the buttons at the bottom of a Page.
 <Canvas>
   <Story name="Custom action">
     {() => {
-      const ACTIONS = [{ type: 'navigate', url: '/profile', label: 'Go to profile' }];
+      const ACTIONS = [{ type: 'navigate', page: 'profile', label: 'Go to profile' }];
       const ON_ACTION = (action, patch, onError) => {
         console.log('action invoked', action, patch);
       };

--- a/src/components/PageActions/PageActions.test.js
+++ b/src/components/PageActions/PageActions.test.js
@@ -46,7 +46,7 @@ describe('components', () => {
     });
 
     it('should appropriately display a custom action', async () => {
-      const ACTIONS = [{ type: 'navigate', url: '/alpha', label: 'Alpha' }];
+      const ACTIONS = [{ type: 'navigate', page: 'alpha', label: 'Alpha' }];
       const { container } = render(
         <PageActions actions={ACTIONS} onAction={ON_ACTION} />
       );
@@ -64,7 +64,7 @@ describe('components', () => {
     });
 
     it('should appropriately display multiple actions', async () => {
-      const NAVIGATE = { type: PageAction.TYPES.NAVIGATE, url: '/alpha', label: 'Alpha' };
+      const NAVIGATE = { type: PageAction.TYPES.NAVIGATE, page: 'alpha', label: 'Alpha' };
       const ACTIONS = [ NAVIGATE, PageAction.TYPES.SUBMIT ];
       const { container } = render(
         <PageActions actions={ACTIONS} onAction={ON_ACTION} />

--- a/src/components/SummaryList/RowAction.jsx
+++ b/src/components/SummaryList/RowAction.jsx
@@ -28,7 +28,7 @@ RowAction.propTypes = {
   row: PropTypes.shape({
     action: PropTypes.shape({
       label: PropTypes.string.isRequired,
-      href: PropTypes.string,
+      page: PropTypes.string,
       aria_suffix: PropTypes.string,
       onAction: PropTypes.func
     })

--- a/src/components/SummaryList/RowAction.test.js
+++ b/src/components/SummaryList/RowAction.test.js
@@ -18,26 +18,26 @@ describe('components', () => {
     });
 
     it('should handle a row with an href in the action', () => {
-      const HREF = 'http://alpha.homeoffice.gov.uk';
-      const ROW = { action: { href: HREF, label: 'Change' } };
+      const PAGE = 'alpha';
+      const ROW = { action: { page: PAGE, label: 'Change' } };
       const { container } = render(
         <RowAction row={ROW} />
       );
       const link = container.childNodes[0];
       expect(link.tagName).toEqual('A');
-      expect(link.getAttribute('href')).toEqual(HREF);
+      expect(link.getAttribute('href')).toEqual(`/${PAGE}`);
       expect(link.textContent).toEqual(ROW.action.label);
     });
 
     it('should render an aria_suffix appropriately', () => {
-      const HREF = 'http://alpha.homeoffice.gov.uk';
-      const ROW = { action: { href: HREF, label: 'Change', aria_suffix: 'the thing' } };
+      const PAGE = 'alpha';
+      const ROW = { action: { page: PAGE, label: 'Change', aria_suffix: 'the thing' } };
       const { container } = render(
         <RowAction row={ROW} />
       );
       const link = container.childNodes[0];
       expect(link.tagName).toEqual('A');
-      expect(link.getAttribute('href')).toEqual(HREF);
+      expect(link.getAttribute('href')).toEqual(`/${PAGE}`);
       expect(link.textContent).toEqual(`${ROW.action.label} ${ROW.action.aria_suffix}`);
     });
 

--- a/src/components/SummaryList/SummaryList.jsx
+++ b/src/components/SummaryList/SummaryList.jsx
@@ -40,7 +40,7 @@ SummaryList.propTypes = {
     key: PropTypes.string.isRequired,
     value: PropTypes.any,
     action: PropTypes.shape({
-      href: PropTypes.string,
+      page: PropTypes.string,
       label: PropTypes.string,
       aria_suffix: PropTypes.string,
       onAction: PropTypes.func

--- a/src/components/SummaryList/helpers/getRowActionAttributes.js
+++ b/src/components/SummaryList/helpers/getRowActionAttributes.js
@@ -2,8 +2,8 @@ const getRowActionAttributes = (row) => {
   if (row && row.action) {
     if (typeof(row.action.onAction) === 'function') {
       return { onClick: () => row.action.onAction(row) };
-    } else {
-      return { href: row.action.href };
+    } else if (row.action.page) {
+      return { href: `/${row.action.page}`};
     }
   }
   return {};

--- a/src/components/SummaryList/helpers/getRowActionAttributes.test.js
+++ b/src/components/SummaryList/helpers/getRowActionAttributes.test.js
@@ -23,12 +23,12 @@ describe('components', () => {
           expect(getRowActionAttributes(ROW)).toEqual({});
         });
 
-        it('should handle a row with an href', () => {
-          const HREF = 'http://alpha.homeoffice.gov.uk';
+        it('should handle a row with a page', () => {
+          const PAGE = 'alpha';
           const ROW = {
-            action: { href: HREF }
+            action: { page: PAGE }
           };
-          expect(getRowActionAttributes(ROW)).toEqual({ href: HREF });
+          expect(getRowActionAttributes(ROW)).toEqual({ href: `/${PAGE}` });
         });
 
         it('should handle a row with an onAction function', () => {

--- a/src/docs/Page.stories.mdx
+++ b/src/docs/Page.stories.mdx
@@ -59,8 +59,8 @@ set to `true` and can be missing from the configuration, which will result in a 
 This dictates what should be shown for this page on the **Check your answers** screen, where applicable. This is not
 needed if `show_on_cya` is set to `false`.
 
-* #### `url: string`
-The url of the page to navigate to, which can be different to the page this is specified on.
+* #### `page: string`
+The id of the page to navigate to, which can be different to the page this is specified on.
 * #### `label: string`
 The label to show on the link. By default this will simply say "Change".
 * #### `aria_suffix : string`

--- a/src/docs/PageExamples.stories.mdx
+++ b/src/docs/PageExamples.stories.mdx
@@ -24,7 +24,7 @@ see <Link href="/?path=/docs/f-json-page">Page JSON</Link>.
   ],
   "actions": ["submit"],
   "cya_link": {
-    "url": "/civil-servant-status",
+    "page": "civil-servant-status",
     "aria_suffix": "civil servant status"
   }
 }

--- a/src/json/firstForm.json
+++ b/src/json/firstForm.json
@@ -42,7 +42,7 @@
         "If you are happy to proceed, click start now."
       ],
       "actions": [
-        { "type": "navigate", "url": "/firstName", "start": true, "label": "Start now" }
+        { "type": "navigate", "page": "firstName", "start": true, "label": "Start now" }
       ],
       "show_on_cya": false
     },
@@ -55,7 +55,7 @@
       ],
       "actions": [ "saveAndContinue", "saveAndReturn" ],
       "cya_link": {
-        "url": "/firstName",
+        "page": "firstName",
         "aria_suffix": "your first name"
       }
     },
@@ -68,7 +68,7 @@
       ],
       "actions": [ "saveAndContinue", "saveAndReturn" ],
       "cya_link": {
-        "url": "/surname",
+        "page": "surname",
         "aria_suffix": "your surname"
       }
     },
@@ -81,7 +81,7 @@
       ],
       "actions": [ "saveAndContinue", "saveAndReturn" ],
       "cya_link": {
-        "url": "/age",
+        "page": "age",
         "aria_suffix": "your first name"
       }
     }

--- a/src/json/saveAndContinue.json
+++ b/src/json/saveAndContinue.json
@@ -39,6 +39,24 @@
       "label": "Incident date and start time",
       "type": "text",
       "required": true
+    },
+    {
+      "id": "seizedItems",
+      "fieldId": "seizedItems",
+      "type": "collection",
+      "required": true,
+      "components": [
+        { "use": "type" },
+        { "use": "description" },
+        {
+          "id": "status",
+          "fieldId": "status",
+          "label": "What is the seized status of this item?",
+          "type": "radios",
+          "required": true
+        }
+      ],
+      "_description": "Required means at least 1 item"
     }
   ],
   "pages": [
@@ -56,7 +74,7 @@
         { "type": "saveAndReturn", "validate": true, "label": "Save and return later", "classModifiers": "secondary" }
       ],
       "cya_link": {
-        "url": "/details",
+        "page": "details",
         "aria_suffix": "your details"
       }
     },
@@ -70,7 +88,7 @@
       ],
       "actions": ["submit"],
       "cya_link": {
-        "url": "/where-and-when",
+        "page": "where-and-when",
         "aria_suffix": "where and when"
       }
     }

--- a/src/json/userProfile.json
+++ b/src/json/userProfile.json
@@ -140,7 +140,7 @@
       ],
       "actions": ["submit"],
       "cya_link": {
-        "url": "/civil-servant-status",
+        "page": "civil-servant-status",
         "aria_suffix": "civil servant status"
       }
     },
@@ -156,7 +156,7 @@
       ],
       "actions": ["submit"],
       "cya_link": {
-        "url": "/grade",
+        "page": "grade",
         "aria_suffix": "grade"
       }
     },
@@ -172,7 +172,7 @@
       ],
       "actions": ["submit"],
       "cya_link": {
-        "url": "/team-name",
+        "page": "team-name",
         "aria_suffix": "teams"
       }
     },
@@ -197,7 +197,7 @@
       "actions": [
         {
           "type": "navigate",
-          "url": "/line-manager-email"
+          "page": "line-manager-email"
         }
       ],
       "show_on_cya": false
@@ -213,7 +213,7 @@
       ],
       "actions": ["submit"],
       "cya_link": {
-        "url": "/add-or-change-line-manager",
+        "page": "add-or-change-line-manager",
         "aria_suffix": "line manager email address"
       }
     },
@@ -232,7 +232,7 @@
       "actions": [
         {
           "type": "navigate",
-          "url": "/delegate-email"
+          "page": "delegate-email"
         }
       ],
       "show_on_cya": false
@@ -249,7 +249,7 @@
       ],
       "actions": ["submit"],
       "cya_link": {
-        "url": "/add-or-change-delegate"
+        "page": "add-or-change-delegate"
       },
       "show_when": [
         {

--- a/src/utils/CheckYourAnswers/getCYAAction.js
+++ b/src/utils/CheckYourAnswers/getCYAAction.js
@@ -2,15 +2,16 @@
  * Gets an action object, configured appropriately for a Check your answers component.
  * 
  * @param {boolean} readonly Whether or not the component is readonly.
- * @param {object} cya_link A configuration object for any link to show.
+ * @param {object} page A configuration object for the page to link to.
  * @param {Function} onAction A function to invoke if the link is clicked.
  * 
  * @returns An action object for a Check your answers row.
  */
-const getCYAAction = (readonly, cya_link, onAction) => {
+const getCYAAction = (readonly, page, onAction) => {
+  const cya_link = page?.cya_link;
   if (readonly !== true && cya_link) {
     return {
-      href: cya_link.url || '#',
+      page: cya_link.page || page.id || '#',
       label: cya_link.label || 'Change',
       aria_suffix: cya_link.aria_suffix,
       onAction

--- a/src/utils/CheckYourAnswers/getCYAAction.test.js
+++ b/src/utils/CheckYourAnswers/getCYAAction.test.js
@@ -6,6 +6,9 @@ describe('utils', () => {
   describe('CheckYourAnswers', () => {
     
     describe('getCYAAction', () => {
+      const getPage = (cya_link, id) => {
+        return { cya_link, id };
+      };
 
       it('should return null if readonly', () => {
         expect(getCYAAction(true, {}, () => {})).toBeNull();
@@ -15,22 +18,33 @@ describe('utils', () => {
         expect(getCYAAction(false, null, () => {})).toBeNull();
       });
 
-      it('should return a default action if the cya_link is empty', () => {
+      it('should return a default action if the cya_link is empty and the page has no id', () => {
         const CYA_LINK = {};
         const ON_ACTION = () => {};
-        expect(getCYAAction(false, CYA_LINK, ON_ACTION)).toEqual({
-          href: '#',
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: '#',
           label: 'Change',
           onAction: ON_ACTION
         });
       });
 
-      it('should use url specified in cya_link', () => {
-        const URL = 'https://fake.url.com/something';
-        const CYA_LINK = { url: URL };
+      it('should return a default action if the cya_link is empty but the page has an id', () => {
+        const PAGE_ID = 'page-id';
+        const CYA_LINK = {};
         const ON_ACTION = () => {};
-        expect(getCYAAction(false, CYA_LINK, ON_ACTION)).toEqual({
-          href: URL,
+        expect(getCYAAction(false, getPage(CYA_LINK, PAGE_ID), ON_ACTION)).toEqual({
+          page: PAGE_ID,
+          label: 'Change',
+          onAction: ON_ACTION
+        });
+      });
+
+      it('should use page specified in cya_link', () => {
+        const PAGE = 'alpha';
+        const CYA_LINK = { page: PAGE };
+        const ON_ACTION = () => {};
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: PAGE,
           label: 'Change',
           onAction: ON_ACTION
         });
@@ -40,8 +54,8 @@ describe('utils', () => {
         const LABEL = 'Alpha Bravo Charlie';
         const CYA_LINK = { label: LABEL };
         const ON_ACTION = () => {};
-        expect(getCYAAction(false, CYA_LINK, ON_ACTION)).toEqual({
-          href: '#',
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: '#',
           label: LABEL,
           onAction: ON_ACTION
         });
@@ -51,8 +65,8 @@ describe('utils', () => {
         const ARIA_SUFFIX = 'This is hidden text';
         const CYA_LINK = { aria_suffix: ARIA_SUFFIX };
         const ON_ACTION = () => {};
-        expect(getCYAAction(false, CYA_LINK, ON_ACTION)).toEqual({
-          href: '#',
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: '#',
           label: 'Change',
           aria_suffix: ARIA_SUFFIX,
           onAction: ON_ACTION
@@ -60,13 +74,13 @@ describe('utils', () => {
       });
 
       it('should use all properties specified in cya_link', () => {
-        const URL = 'https://fake.url.com/something';
+        const PAGE = 'alpha';
         const LABEL = 'Alpha Bravo Charlie';
         const ARIA_SUFFIX = 'This is hidden text';
-        const CYA_LINK = { label: LABEL, url: URL, aria_suffix: ARIA_SUFFIX };
+        const CYA_LINK = { label: LABEL, page: PAGE, aria_suffix: ARIA_SUFFIX };
         const ON_ACTION = () => {};
-        expect(getCYAAction(false, CYA_LINK, ON_ACTION)).toEqual({
-          href: URL,
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: PAGE,
           label: LABEL,
           aria_suffix: ARIA_SUFFIX,
           onAction: ON_ACTION

--- a/src/utils/CheckYourAnswers/getCYARow.js
+++ b/src/utils/CheckYourAnswers/getCYARow.js
@@ -17,8 +17,8 @@ const getCYARow = (page, component, onAction) => {
     fieldId: component.fieldId,
     key: component.label || component.cya_label,
     component: Component.editable(component) ? component : undefined,
-    value: page.formData[component.fieldId] || '',
-    action: getCYAAction(component.readonly, page.cya_link, onAction)
+    value: page.formData && component.fieldId ? page.formData[component.fieldId] || '' : '',
+    action: getCYAAction(component.readonly, page, onAction)
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4325,10 +4325,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-0.8.1.tgz#ec6bddea61bd0425a0f629260eef8ac6d61d7728"
-  integrity sha512-WsBuSi/NyBgjP7K7oJq/YblRf93Gb32Y7qQzIzjuWuyBnokJSnRz2YHrjKVqkBK5bus2XrnTJ/TSRp1uMO57mQ==
+"@ukhomeoffice/cop-react-components@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-0.8.2.tgz#655cc4a92cf9326ad884bd7e1c1a0813ff54822f"
+  integrity sha512-0SFy3OGmM3dpRYMuLs2EPB9d8sU2Y2nfZuOk3xaCUzlT7ufwNdgS/7aJftMRoTEH3n6LmVpzV5w0hy9/g5zswA==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"


### PR DESCRIPTION
### Description
Refactored page actions and the **Check your answers** links to use `page` as a property rather than mixing and matching `href` and `url`. We presently only ever navigate internally within the form so `page` makes the most sense. This refactor is necessary for saving the form status in a later PR.

https://support.cop.homeoffice.gov.uk/browse/COP-10035

### To test
All of the affected unit tests have been updated, as have the various Storybook stories and JSON files. You can test this by making sure that you can still navigate around within the form in Storybook.

### Release note
This is a major release due to the refactor - existing JSON files (of which there should be almost none in the wild) - will need to be adjusted along the lines of:
```
"pages" : [
  {
    ...
    "actions": [
      { "type": "navigate", "label": "Next", "url": "/page-x" } // Replace this...
      { "type": "navigate", "label": "Next", "page": "page-x" } // ... with this
    ],
    "cya_link": [
      { "url": "/this-page" } // And replace this...
      { "page": "this-page" } // ... with this
    ]
  }
]
```