### PR TITLE
COP-10241: Support url and href on Page and CYA actions

### DIFF
--- a/src/utils/CheckYourAnswers/getCYAAction.js
+++ b/src/utils/CheckYourAnswers/getCYAAction.js
@@ -1,3 +1,14 @@
+const getPageFromCYALink = (link) => {
+  if (link.page) {
+    return link.page;
+  }
+  const url = link.href || link.url;
+  if (url) {
+    return url.split('/').pop();
+  }
+  return undefined;
+};
+
 /**
  * Gets an action object, configured appropriately for a Check your answers component.
  * 
@@ -6,12 +17,16 @@
  * @param {Function} onAction A function to invoke if the link is clicked.
  * 
  * @returns An action object for a Check your answers row.
+ * @description
+ * `cya_link.href` and `cya_link.url` have been deprecated in favour of `cya_link.page` but this
+ * method will convert both by taking the final part of the relative path:
+ * - `href: '/bravo'` => `page: 'bravo'`
  */
 const getCYAAction = (readonly, page, onAction) => {
   const cya_link = page?.cya_link;
   if (readonly !== true && cya_link) {
     return {
-      page: cya_link.page || page.id || '#',
+      page: getPageFromCYALink(cya_link) || page.id || '#',
       label: cya_link.label || 'Change',
       aria_suffix: cya_link.aria_suffix,
       onAction

--- a/src/utils/CheckYourAnswers/getCYAAction.test.js
+++ b/src/utils/CheckYourAnswers/getCYAAction.test.js
@@ -50,6 +50,28 @@ describe('utils', () => {
         });
       });
 
+      it('should convert an href specified in cya_link', () => {
+        const HREF = '/alpha/bravo';
+        const CYA_LINK = { href: HREF };
+        const ON_ACTION = () => {};
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: 'bravo',
+          label: 'Change',
+          onAction: ON_ACTION
+        });
+      });
+
+      it('should convert a url specified in cya_link', () => {
+        const URL = '/alpha/bravo';
+        const CYA_LINK = { url: URL };
+        const ON_ACTION = () => {};
+        expect(getCYAAction(false, getPage(CYA_LINK), ON_ACTION)).toEqual({
+          page: 'bravo',
+          label: 'Change',
+          onAction: ON_ACTION
+        });
+      });
+
       it('should use label specified in cya_link', () => {
         const LABEL = 'Alpha Bravo Charlie';
         const CYA_LINK = { label: LABEL };

--- a/src/utils/FormPage/getFormPage.js
+++ b/src/utils/FormPage/getFormPage.js
@@ -1,5 +1,6 @@
 // Local imports
 import Data from '../Data';
+import getPageActions from './getPageActions';
 import getParagraphFromText from './getParagraphFromText';
 import useComponent from './useComponent';
 
@@ -27,10 +28,12 @@ const getFormPage = (pageOptions, formComponents, formData) => {
 
     return formData && formData.urls ? Data.refData.setupUrl(ret, formData) : ret;
   });
+  const actions = getPageActions(pageOptions);
   return {
     ...pageOptions,
     formData,
-    components
+    components,
+    actions
   };
 };
 

--- a/src/utils/FormPage/getPageActions.js
+++ b/src/utils/FormPage/getPageActions.js
@@ -1,0 +1,42 @@
+import { PageAction } from '../../models';
+
+const standardiseAction = (obj) => {
+  const action = { ...obj };
+  // This is in place for backwards compatibility with version 1.
+  if (!action.page) {
+    if (action.href) {
+      action.page = action.href.split('/').pop();
+    } else if (action.url) {
+      action.page = action.url.split('/').pop();
+    }
+  }
+  return action;
+};
+
+/**
+ * Gets an array of standardised action objects for a page.
+ * @param {object} page The page to get the actions for.
+ * @returns Standardised action objects.
+ * @description Standardises actions specified on a page into ones suitable for this version of the
+ * Form Renderer.
+ * 
+ * `action.href` and `action.url` have been deprecated in favour of `action.page` but this method
+ * will convert both by taking the final part of the relative path:
+ * - `href: '/bravo'` => `page: 'bravo'`
+ */
+const getPageActions = (page) => {
+  if (page && Array.isArray(page.actions)) {
+    return page.actions.map(a => {
+      if (typeof a === 'string') {
+        return PageAction.DEFAULTS[a];
+      }
+      if (a && typeof a === 'object') {
+        return standardiseAction(a);
+      }
+      return undefined;
+    }).filter(a => !!a);
+  }
+  return undefined;
+};
+
+export default getPageActions;

--- a/src/utils/FormPage/getPageActions.test.js
+++ b/src/utils/FormPage/getPageActions.test.js
@@ -1,0 +1,69 @@
+// Local imports
+import { PageAction } from '../../models';
+import getPageActions from './getPageActions';
+
+describe('utils', () => {
+
+  describe('FormPage', () => {
+
+    describe('getPageActions', () => {
+
+      it('should handle a null or undefined page', () => {
+        expect(getPageActions(null)).toBeUndefined();
+        expect(getPageActions(undefined)).toBeUndefined();
+      });
+
+      it('should handle a null or undefined actions array', () => {
+        expect(getPageActions({ actions: null })).toBeUndefined();
+        expect(getPageActions({ actions: undefined })).toBeUndefined();
+      });
+
+      it('should handle an array of strings', () => {
+        const actions = [PageAction.TYPES.SAVE_AND_CONTINUE, PageAction.TYPES.SAVE_AND_RETURN];
+        expect(getPageActions({ actions })).toEqual([
+          PageAction.DEFAULTS.saveAndContinue,
+          PageAction.DEFAULTS.saveAndReturn
+        ]);
+      });
+
+      it('should handle a null entry in the array', () => {
+        const actions = [PageAction.TYPES.SAVE_AND_CONTINUE, PageAction.TYPES.SAVE_AND_RETURN, null];
+        expect(getPageActions({ actions })).toEqual([
+          PageAction.DEFAULTS.saveAndContinue,
+          PageAction.DEFAULTS.saveAndReturn
+        ]);
+      });
+
+      it('should handle an undefined entry in the array', () => {
+        const actions = [undefined, PageAction.TYPES.SAVE_AND_CONTINUE, undefined, PageAction.TYPES.SAVE_AND_RETURN];
+        expect(getPageActions({ actions })).toEqual([
+          PageAction.DEFAULTS.saveAndContinue,
+          PageAction.DEFAULTS.saveAndReturn
+        ]);
+      });
+
+      it('should handle an object entry in the array', () => {
+        const actions = [{ type: 'navigate', page: 'alpha' }];
+        expect(getPageActions({ actions })).toEqual(actions);
+      });
+
+      it('should convert an href to a page', () => {
+        const actions = [{ type: 'navigate', href: '/alpha/bravo' }];
+        expect(getPageActions({ actions })).toEqual([{ type: 'navigate', page: 'bravo', href: '/alpha/bravo' }]);
+      });
+
+      it('should convert a url to a page', () => {
+        const actions = [{ type: 'navigate', url: '/alpha/bravo' }];
+        expect(getPageActions({ actions })).toEqual([{ type: 'navigate', page: 'bravo', url: '/alpha/bravo' }]);
+      });
+
+      it('should handle an action without a page, href, or url', () => {
+        const actions = [{ type: 'submit', label: 'Charlie' }];
+        expect(getPageActions({ actions })).toEqual(actions);
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
### Description
Added utility functions to standardise Page and CYA actions and offer backwards compatibility with version 1.x of the Form Renderer, which used `href` and `url`. Both now just use `page`.

### To test
This should be covered by the accompanying unit tests.