### PR TITLE
COP-10241: Fix logic for determining the next form page

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.0.0-beta",
+    "@ukhomeoffice/cop-react-components": "1.1.2",
     "axios": "^0.21.1",
     "govuk-frontend": "^3.13.0",
     "web-vitals": "^1.0.1"

--- a/src/components/FormPage/FormPage.test.js
+++ b/src/components/FormPage/FormPage.test.js
@@ -59,10 +59,10 @@ describe('components', () => {
       expect(input.value).toEqual(VALUE);
       const buttonGroup = page.childNodes[2];
       expect(buttonGroup.tagName).toEqual('DIV');
-      expect(buttonGroup.classList).toContain('govuk-button-group');
+      expect(buttonGroup.classList).toContain('hods-button-group');
       const button = buttonGroup.childNodes[0];
       expect(button.tagName).toEqual('BUTTON');
-      expect(button.classList).toContain('govuk-button');
+      expect(button.classList).toContain('hods-button');
       expect(button.textContent).toEqual(DEFAULT_LABEL);
     });
 

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -56,6 +56,13 @@ const FormRenderer = ({
     setPages(Utils.FormPage.getAll(_pages, components, { ...data }));
   }, [components, _pages, data, setPages]);
 
+  // Setup initial pageId.
+  useEffect(() => {
+    setPageId(prev => {
+      return prev || helpers.getNextPageId(type, pages);
+    });
+  }, [type, pages, setPageId]);
+
   // Setup hub.
   useEffect(() => {
     setHub(Utils.Hub.get(type, _hub, components, { ...data }));
@@ -92,9 +99,11 @@ const FormRenderer = ({
         // Now submit the data to the backend...
         hooks.onSubmit(action.type, submissionData, (response) => {
           // The backend response may well contain data we need so apply it.
-          setData(prev => ({ ...prev, ...response }));
-          const nextPageId = helpers.getNextPageId(type, pages, pageId, action);
-          onPageChange(nextPageId);
+          setData(prev => {
+            const next = { ...prev, ...response };
+            onPageChange(helpers.getNextPageId(type, pages, pageId, action, next));
+            return next;
+          });
         }, (errors) => {
           handlers.submissionError(errors, onError);
         });

--- a/src/components/FormRenderer/helpers/getNextPageId.js
+++ b/src/components/FormRenderer/helpers/getNextPageId.js
@@ -1,45 +1,47 @@
 import { FormPages, FormTypes, PageAction } from '../../../models';
+import FormPage from '../../../utils/FormPage';
 
 const getNextHubPageId = (action) => {
-  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
-    return FormPages.HUB;
-  }
-  return action?.nextPageId || FormPages.HUB;
+  return action?.page || FormPages.HUB;
 };
 
-const getNextCYAPageId = (pages, currentPageId, action) => {
-  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
-    return undefined;
-  }
-  const nextIndex = pages.findIndex(p => p.id === currentPageId) + 1;
-  return nextIndex < pages.length ? pages[nextIndex].id : FormPages.CYA;
+const getNextCYAPageId = (pages, currentPageId, formData) => {
+  return getNextWizardPageId(pages, currentPageId, formData) || FormPages.CYA;
 };
 
-const getNextWizardPageId = (pages, currentPageId, action) => {
-  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
-    return undefined;
+const getNextWizardPageId = (pages, currentPageId, formData) => {
+  let nextIndex = pages.findIndex(p => p.id === currentPageId) + 1;
+  let page = pages[nextIndex];
+  while (page && !FormPage.show(page, formData)) {
+    nextIndex++;
+    page = pages[nextIndex];
   }
-  const nextIndex = pages.findIndex(p => p.id === currentPageId) + 1;
-  return nextIndex < pages.length ? pages[nextIndex].id : undefined;
+  return page?.id || undefined;
 };
 
-const getNextFormPageId = (pages, action) => {
-  if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
-    return undefined;
-  }
+const getNextFormPageId = (pages) => {
+  // A form has a single page... so always return that id.
   return pages.length > 0 ? pages[0].id : undefined;
 };
 
-const getNextPageId = (formType, pages, currentPageId, action) => {
+const getNextPageId = (formType, pages, currentPageId, action, formData) => {
+  if (action) {
+    if (action.type === PageAction.TYPES.NAVIGATE) {
+      return pages.find(p => p.id === action.page) ? action.page : undefined;
+    }
+    if (action.type === PageAction.TYPES.SAVE_AND_RETURN) {
+      return formType === FormTypes.HUB ? FormPages.HUB : undefined;
+    }
+  }
   switch (formType) {
     case FormTypes.HUB:
       return getNextHubPageId(action);
     case FormTypes.CYA:
-      return getNextCYAPageId(pages, currentPageId, action);
+      return getNextCYAPageId(pages, currentPageId, formData);
     case FormTypes.WIZARD:
-      return getNextWizardPageId(pages, currentPageId, action);
+      return getNextWizardPageId(pages, currentPageId, formData);
     default:
-      return getNextFormPageId(pages, action);
+      return getNextFormPageId(pages);
   }
 };
 

--- a/src/components/FormRenderer/helpers/getNextPageId.test.js
+++ b/src/components/FormRenderer/helpers/getNextPageId.test.js
@@ -1,5 +1,5 @@
 // Local imports
-import { FormPages, FormTypes, PageAction } from '../../../models';
+import { ComponentTypes, FormPages, FormTypes, PageAction } from '../../../models';
 import getNextPageId from './getNextPageId';
 
 describe('components', () => {
@@ -9,11 +9,42 @@ describe('components', () => {
     describe('helpers', () => {
 
       describe('getNextPageId', () => {
-
+        const OPTIONS = [ { value: 'romeo', label: 'Romeo'}, { value: 'juliet', label: 'Juliet' } ];
+        const RADIOS = { id: 'radios', fieldId: 'radios', type: ComponentTypes.RADIOS, data: { options: OPTIONS } };
+        const TEXT = { id: 'text', fieldId: 'text', type: ComponentTypes.TEXT };
+        const HTML = { type: ComponentTypes.HTML, content: 'HTML' };
+        const SHOW_WHEN_JULIET = { field: RADIOS.fieldId, op: '=', value: OPTIONS[1].value };
+        const SHOW_WHEN_ROMEO = { field: RADIOS.fieldId, op: '=', value: OPTIONS[0].value };
+        const FORM_DATA = { radios: OPTIONS[0].value }; // 'romeo'
         const PAGES = [
           { id: 'alpha' },
-          { id: 'bravo' }
+          { id: 'bravo' },
+          { id: 'charlie', components: [ RADIOS ]},
+          { id: 'delta', components: [ TEXT ], show_when: SHOW_WHEN_JULIET },
+          { id: 'echo', components: [ HTML ]},
+          { id: 'foxtrot', components: [ TEXT ], show_when: SHOW_WHEN_ROMEO }
         ];
+
+        describe(`when the action type is '${PageAction.TYPES.NAVIGATE}'`, () => {
+
+          it('should return undefined if the action has no page property', () => {
+            const ACTION = { type: PageAction.TYPES.NAVIGATE };
+            expect(getNextPageId(FormTypes.HUB, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toBeUndefined();
+          });
+
+          it('should return the page on the action if it exists among the pages', () => {
+            const PAGE = PAGES[1].id;
+            const ACTION = { type: PageAction.TYPES.NAVIGATE, page: PAGE };
+            expect(getNextPageId(FormTypes.HUB, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toEqual(PAGE);
+          });
+
+          it('should return undefined if the page on the action does not exist among the pages', () => {
+            const PAGE = 'golf';
+            const ACTION = { type: PageAction.TYPES.NAVIGATE, page: PAGE };
+            expect(getNextPageId(FormTypes.HUB, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toBeUndefined();
+          });
+
+        });
 
         describe(`when the form type is '${FormTypes.HUB}'`, () => {
           const FORM_TYPE = FormTypes.HUB;
@@ -24,12 +55,12 @@ describe('components', () => {
 
           it(`should return '${FormPages.HUB}' if the action is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
             const ACTION = PageAction.DEFAULTS.saveAndReturn;
-            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toEqual(FormPages.HUB);
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toEqual(FormPages.HUB);
           });
 
-          it('should return action.nextPageId if specified', () => {
-            const ACTION = { nextPageId: 'bob' };
-            expect(getNextPageId(FORM_TYPE, PAGES, undefined, ACTION)).toEqual(ACTION.nextPageId);
+          it('should return action.page if specified', () => {
+            const ACTION = { page: 'bob' };
+            expect(getNextPageId(FORM_TYPE, PAGES, undefined, ACTION, FORM_DATA)).toEqual(ACTION.page);
           });
 
         });
@@ -45,13 +76,21 @@ describe('components', () => {
             expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id)).toEqual(PAGES[1].id);
           });
 
-          it(`should return '${FormPages.CYA}' when on the last page`, () => {
-            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[PAGES.length - 1].id)).toEqual(FormPages.CYA);
+          it('should return the third page when on the second page', () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[1].id)).toEqual(PAGES[2].id);
+          });
+
+          it(`should return the fifth page when on the third page because the fourth page show_when is not met`, () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[2].id, PageAction.DEFAULTS.saveAndContinue, FORM_DATA)).toEqual(PAGES[4].id);
+          });
+
+          it(`should return the sixth page when on the fifth page because the sixth page show_when is met`, () => {
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[4].id, PageAction.DEFAULTS.saveAndContinue, FORM_DATA)).toEqual(PAGES[5].id);
           });
 
           it(`should return undefined if the action is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
             const ACTION = PageAction.DEFAULTS.saveAndReturn;
-            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION)).toBeUndefined();
+            expect(getNextPageId(FORM_TYPE, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toBeUndefined();
           });
 
         });

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -1,7 +1,8 @@
 // Local imports
 import { ComponentTypes } from '../../models';
-import validateRequired from './validateRequired';
+import showComponent from '../Component/showComponent';
 import validateEmail from './validateEmail';
+import validateRequired from './validateRequired';
 
 /**
  * Validates a single component.
@@ -12,7 +13,7 @@ import validateEmail from './validateEmail';
 const validateComponent = (component, formData) => {
   let error = undefined;
   const data = formData && typeof(formData) === 'object' ? formData : {};
-  if (component) {
+  if (component && showComponent(component, formData)) {
     const value = data[component.fieldId];
     if (component.required) {
       error = validateRequired(value, component.label);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4325,10 +4325,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.0.0-beta":
-  version "1.0.0-beta"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.0.0-beta.tgz#3b9b12e0fa7bd192e501307990211f2fd4c1b411"
-  integrity sha512-DtfK7H9E9NzCawLrZXfwu9oS7/WC5VdaNwYkpYqiRBER4eCHsSyYKjz2/HeGejbEIcp95gtsDt8KfyHhy9ltnw==
+"@ukhomeoffice/cop-react-components@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.1.1.tgz#bc3d7d78a019a9863f1108973555e71ccf4c813e"
+  integrity sha512-ZqTJ4dVVfesBmiezhkGfQ31jJu/2w7K/TstZYxHa1gn5bUATGzjAXeFICt+bMICGWBmn6Mf1Nzan0Uwa/waI8A==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4325,10 +4325,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.1.1.tgz#bc3d7d78a019a9863f1108973555e71ccf4c813e"
-  integrity sha512-ZqTJ4dVVfesBmiezhkGfQ31jJu/2w7K/TstZYxHa1gn5bUATGzjAXeFICt+bMICGWBmn6Mf1Nzan0Uwa/waI8A==
+"@ukhomeoffice/cop-react-components@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.1.2.tgz#0719ed2cb3456e1a9c15de9987ade78fa96d67b6"
+  integrity sha512-ciJKEeyNeOV5xxWWpGaWW4g5pvs4j3TUTieiI9lQQjGM3FpzsHwaLCyNY3q/jKowVyW+30EXLikE41FgKQQXYw==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"


### PR DESCRIPTION
### Description
Fixed the logic for determining the next page in the form, which now properly assesses the state of the data captured on the form to see whether a page's visibility is affected by it.

### To test
Covered by accompanying unit tests. You can see the behaviour in the Sandbox, though, by setting up a form with 3 pages and making the 2nd page only show if a field on the first page has a particular value. Previously, it would have just shown the 2nd page anyway; now it will skip to the next page and see if _that_ one should be shown... all the way to the end of the CYA screen if appropriate.