### PR TITLE
COP-10241: Fix issue with fields not hiding on page

### DIFF
--- a/src/components/FormPage/FormPage.jsx
+++ b/src/components/FormPage/FormPage.jsx
@@ -35,18 +35,23 @@ const FormPage = ({
     }));
   };
 
+  const onError = (errors) => {
+    setErrors(errors);
+  };
+
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
     <div className={classes('page')} key={page.id}>
       {page.title && <LargeHeading>{page.title}</LargeHeading>}
       {errors && errors.length > 0 && <ErrorSummary errors={errors} />}
-      {page.components.map((component, index) => (
+      {page.components.filter(c => Utils.Component.show(c, page.formData)).map((component, index) => (
         <FormComponent key={index}
           component={component}
           onChange={onPageChange}
-          value={page.formData[component.fieldId] || ''} />
+          value={page.formData[component.fieldId] || ''}
+        />
       ))}
-      <PageActions actions={page.actions} onAction={(action) => onAction(action, patch, setErrors)} />
+      <PageActions actions={page.actions} onAction={(action) => onAction(action, patch, onError)} />
     </div>
   );
 };


### PR DESCRIPTION
### Description
The fields on a page should hide if they have a `show_when` condition that is not met. That wasn't happening correctly.