### PR TITLE
Chore: Code cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/docs/FormTypes.stories.mdx
+++ b/src/docs/FormTypes.stories.mdx
@@ -8,14 +8,9 @@ import { Alert, Heading, Link, Tag } from '@ukhomeoffice/cop-react-components';
 
 <Heading size="xl" id="json-form" caption="JSON Format">Form types</Heading>
 
-<Alert heading="Note" classModifiers="error">
-  Hub-and-spoke is the only type presently implemented. The others are works in progress.
-</Alert>
-
 The form types available in the JSON for rendering a <Link href="/?path=/docs/d-formrenderer">Form</Link>.
 
 ## `cya`
-<Tag>Yet to do</Tag>
 
 A form made up of a series of <Link href="/?path=/docs/f-json-page">pages</Link>,
 which then has a **Check your answers** screen at the end, prior to a final submission.
@@ -25,7 +20,6 @@ that <Link href="/?path=/docs/f-json-page">page</Link>.
 
 
 ## `form`
-<Tag>Yet to do</Tag>
 
 A simple single-page form. No bells or whistles on this one.
 
@@ -44,7 +38,6 @@ there *isn't* a flow - the user is returned to the hub at the conclusion of each
 
 
 ## `wizard`
-<Tag>Yet to do</Tag>
 
 A form made up of a series of <Link href="/?path=/docs/f-json-page">pages</Link>, with **Continue**
 (next) and **Back** (previous) navigation options on each <Link href="/?path=/docs/f-json-page">page</Link>.

--- a/src/docs/Sandbox.stories.mdx
+++ b/src/docs/Sandbox.stories.mdx
@@ -71,6 +71,7 @@ import './Sandbox.stories.scss';
       setComplete(true);
     });
     addHook('onSubmit', (type, payload, onSuccess, onError) => {
+      console.log('onSubmit called', type, payload);
       setSubmittedData(payload);
       onSuccess();
     });

--- a/src/utils/CheckYourAnswers/getCYARow.js
+++ b/src/utils/CheckYourAnswers/getCYARow.js
@@ -12,12 +12,16 @@ import getCYAAction from './getCYAAction';
  * @returns A configuration object for a Check your answers row.
  */
 const getCYARow = (page, component, onAction) => {
+  let value = '';
+  if (page.formData && component.fieldId) {
+    value = page.formData[component.fieldId];
+  }
   return {
     pageId: page.id,
     fieldId: component.fieldId,
     key: component.label || component.cya_label,
     component: Component.editable(component) ? component : undefined,
-    value: page.formData && component.fieldId ? page.formData[component.fieldId] || '' : '',
+    value: value || '',
     action: getCYAAction(component.readonly, page, onAction)
   };
 };


### PR DESCRIPTION
### Description
A little bit of refactoring in one of the functions to clean up the setting of a `value` property (so it's not a mess of ternary operators and `||`s). Also sorted out some Storybook stories.

Finally, got rid of the pre-release suffix on the version as this should now be in a releasable state (`-alpha` is what I've been using to test things within COP UI).

### To test
There's nothing here to test - the unit tests for the utility function continue to pass.