### PR TITLE
EAB-142 Add custom required error messages

### DIFF
--- a/src/docs/Component.stories.mdx
+++ b/src/docs/Component.stories.mdx
@@ -48,6 +48,11 @@ Whether or not the field is required (defaults to `false`).
 If this is `false`, the label will have an '(optional)' suffix; if this is `true`,
 an error will be shown if the field is not populated.
 
+### `customError : string`
+*Optional, and only applicable to <Link href="/?path=/docs/f-editable-components">editable components</Link>*
+
+The error message that should be displayed if the `required` validation is failed.
+
 ### `readonly: boolean`
 *Optional, and only applicable to <Link href="/?path=/docs/f-editable-components">editable components</Link>*
 

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -16,7 +16,7 @@ const validateComponent = (component, formData) => {
   if (component && showComponent(component, formData)) {
     const value = data[component.fieldId];
     if (component.required) {
-      error = validateRequired(value, component.label);
+      error = validateRequired(value, component.label, component.customError);
     }
     if (!error && component.type === ComponentTypes.EMAIL) {
       error = validateEmail(value, component.label);

--- a/src/utils/Validate/validateRequired.js
+++ b/src/utils/Validate/validateRequired.js
@@ -5,7 +5,7 @@
  * @param {string} label The label to use in any error message.
  * @returns An error if the value is nullish.
  */
-const validateRequired = (value, label = '') => {
+const validateRequired = (value, label = '', customError) => {
   let hasValue = false;
   if (!!value || value === false || value === 0) {
     hasValue = true;
@@ -16,6 +16,9 @@ const validateRequired = (value, label = '') => {
     }
   }
   if (!hasValue) {
+    if(customError){
+      return customError;
+    }
     const name = label ? label : 'Field';
     return `${name} is required`;
   }

--- a/src/utils/Validate/validateRequired.test.js
+++ b/src/utils/Validate/validateRequired.test.js
@@ -45,6 +45,9 @@ describe('utils', () => {
       it('should use a default label when none is specified', () => {
         expect(validateRequired(undefined, undefined)).toEqual('Field is required');
       });
+      it('should use a custom label when one is provided', () => {
+        expect(validateRequired(undefined, undefined, 'custom error message')).toEqual('custom error message');
+      });
 
     });
 


### PR DESCRIPTION
New EAB screen designs require a variety of error messages to be displayed with a user does not complete a component that they should complete. This PR adds the ability to specific in the JSON what the error message should say. 