### PR TITLE
EAB-142 Add custom required error messages

### DIFF
--- a/src/docs/Component.stories.mdx
+++ b/src/docs/Component.stories.mdx
@@ -48,10 +48,17 @@ Whether or not the field is required (defaults to `false`).
 If this is `false`, the label will have an '(optional)' suffix; if this is `true`,
 an error will be shown if the field is not populated.
 
-### `customError : string`
+### `custom_error : object`
 *Optional, and only applicable to <Link href="/?path=/docs/f-editable-components">editable components</Link>*
 
-The error message that should be displayed if the `required` validation is failed.
+The error message that should be displayed if a validation check is failed, currently usable on the `required` validator.
+
+Structured as: `"custom_errors": [
+  {
+    "type": "required",
+    "message": "Custom message here"
+  }
+]`
 
 ### `readonly: boolean`
 *Optional, and only applicable to <Link href="/?path=/docs/f-editable-components">editable components</Link>*

--- a/src/docs/Component.stories.mdx
+++ b/src/docs/Component.stories.mdx
@@ -48,6 +48,11 @@ Whether or not the field is required (defaults to `false`).
 If this is `false`, the label will have an '(optional)' suffix; if this is `true`,
 an error will be shown if the field is not populated.
 
+### `customError : string`
+*Optional, and only applicable to <Link href="/?path=/docs/f-editable-components">editable components</Link>*
+
+The error message that should be displayed if the `required` validation is failed.
+
 ### `readonly: boolean`
 *Optional, and only applicable to <Link href="/?path=/docs/f-editable-components">editable components</Link>*
 

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -16,7 +16,7 @@ const validateComponent = (component, formData) => {
   if (component && showComponent(component, formData)) {
     const value = data[component.fieldId];
     if (component.required) {
-      error = validateRequired(value, component.label);
+      error = validateRequired(value, component.label, component.customError);
     }
     if (!error && component.type === ComponentTypes.EMAIL) {
       error = validateEmail(value, component.label);

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -16,7 +16,7 @@ const validateComponent = (component, formData) => {
   if (component && showComponent(component, formData)) {
     const value = data[component.fieldId];
     if (component.required) {
-      error = validateRequired(value, component.label, component.customError);
+      error = validateRequired(value, component.label, component.custom_errors);
     }
     if (!error && component.type === ComponentTypes.EMAIL) {
       error = validateEmail(value, component.label);

--- a/src/utils/Validate/validateRequired.js
+++ b/src/utils/Validate/validateRequired.js
@@ -5,7 +5,7 @@
  * @param {string} label The label to use in any error message.
  * @returns An error if the value is nullish.
  */
-const validateRequired = (value, label = '') => {
+const validateRequired = (value, label = '', customError) => {
   let hasValue = false;
   if (!!value || value === false || value === 0) {
     hasValue = true;
@@ -16,6 +16,9 @@ const validateRequired = (value, label = '') => {
     }
   }
   if (!hasValue) {
+    if(customError){
+      return customError;
+    }
     const name = label ? label : 'Field';
     return `${name} is required`;
   }

--- a/src/utils/Validate/validateRequired.js
+++ b/src/utils/Validate/validateRequired.js
@@ -16,11 +16,11 @@ const validateRequired = (value, label = '', customErrors) => {
     }
   }
   if (!hasValue) {
-    if(customErrors && Array.isArray(customErrors)){
-      const result = customErrors.filter(error => {
+    if (Array.isArray(customErrors)) {
+      const result = customErrors.filter((error) => {
         return error.type === 'required';
-      })
-      if(result && result.length > 0 && result[0].message){
+      });
+      if (result && result.length > 0 && result[0].message) {
         return result[0].message;
       }
     }

--- a/src/utils/Validate/validateRequired.js
+++ b/src/utils/Validate/validateRequired.js
@@ -5,7 +5,7 @@
  * @param {string} label The label to use in any error message.
  * @returns An error if the value is nullish.
  */
-const validateRequired = (value, label = '', customError) => {
+const validateRequired = (value, label = '', customErrors) => {
   let hasValue = false;
   if (!!value || value === false || value === 0) {
     hasValue = true;
@@ -16,8 +16,13 @@ const validateRequired = (value, label = '', customError) => {
     }
   }
   if (!hasValue) {
-    if(customError){
-      return customError;
+    if(customErrors && Array.isArray(customErrors)){
+      const result = customErrors.filter(error => {
+        return error.type === "required";
+      })
+      if(result && result.length > 0 && result[0].message){
+        return result[0].message;
+      }
     }
     const name = label ? label : 'Field';
     return `${name} is required`;

--- a/src/utils/Validate/validateRequired.js
+++ b/src/utils/Validate/validateRequired.js
@@ -18,7 +18,7 @@ const validateRequired = (value, label = '', customErrors) => {
   if (!hasValue) {
     if(customErrors && Array.isArray(customErrors)){
       const result = customErrors.filter(error => {
-        return error.type === "required";
+        return error.type === 'required';
       })
       if(result && result.length > 0 && result[0].message){
         return result[0].message;

--- a/src/utils/Validate/validateRequired.test.js
+++ b/src/utils/Validate/validateRequired.test.js
@@ -45,10 +45,10 @@ describe('utils', () => {
       it('should use a default label when none is specified', () => {
         expect(validateRequired(undefined, undefined)).toEqual('Field is required');
       });
-      it('should use a custom label when one is provided', () => {
+      it('should use a custom error when one is provided', () => {
         expect(validateRequired(undefined, undefined, [{type: 'required', message: 'custom error message'}])).toEqual('custom error message');
       });
-      it('should ignore a custom label when not of type required', () => {
+      it('should ignore a custom error when not of type required', () => {
         expect(validateRequired(undefined, undefined, [{type: 'genericError', message: 'generic error message'}])).toEqual('Field is required');
       });
 

--- a/src/utils/Validate/validateRequired.test.js
+++ b/src/utils/Validate/validateRequired.test.js
@@ -45,6 +45,9 @@ describe('utils', () => {
       it('should use a default label when none is specified', () => {
         expect(validateRequired(undefined, undefined)).toEqual('Field is required');
       });
+      it('should use a custom label when one is provided', () => {
+        expect(validateRequired(undefined, undefined, 'custom error message')).toEqual('custom error message');
+      });
 
     });
 

--- a/src/utils/Validate/validateRequired.test.js
+++ b/src/utils/Validate/validateRequired.test.js
@@ -46,7 +46,10 @@ describe('utils', () => {
         expect(validateRequired(undefined, undefined)).toEqual('Field is required');
       });
       it('should use a custom label when one is provided', () => {
-        expect(validateRequired(undefined, undefined, 'custom error message')).toEqual('custom error message');
+        expect(validateRequired(undefined, undefined, [{type: 'required', message: 'custom error message'}])).toEqual('custom error message');
+      });
+      it('should ignore a custom label when not of type required', () => {
+        expect(validateRequired(undefined, undefined, [{type: 'genericError', message: 'generic error message'}])).toEqual('Field is required');
       });
 
     });


### PR DESCRIPTION
Designs for new EAB screens require a variety of error messages to be displayed when required validation is failed. This PR adds the capability to specify custom messages for this purpose in the JSON.