### PR TITLE
Feature/cop 10344/caseview v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/CheckYourAnswers/CheckYourAnswers.jsx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.jsx
@@ -1,5 +1,9 @@
 // Global imports
-import { ErrorSummary, LargeHeading, MediumHeading } from '@ukhomeoffice/cop-react-components';
+import {
+  ErrorSummary,
+  LargeHeading,
+  MediumHeading
+} from '@ukhomeoffice/cop-react-components';
 import PropTypes from 'prop-types';
 import React, { Fragment, useEffect, useState } from 'react';
 
@@ -22,7 +26,11 @@ const CheckYourAnswers = ({
   onAction,
   onRowAction,
   hide_page_titles,
-  hide_actions
+  hide_actions,
+  hide_title,
+  summaryListClassModifiers,
+  noAction,
+  invertWeight
 }) => {
   const [pages, setPages] = useState([]);
   const [errors, setErrors] = useState([]);
@@ -32,19 +40,29 @@ const CheckYourAnswers = ({
       const rows = Utils.CheckYourAnswers.getRows(page, onRowAction);
       return rows.map((row, index) => ({
         ...row,
-        value: <Answer key={`${pageIndex}_${index}`} value={row.value} component={row.component} />
+        value: (
+          <Answer
+            key={`${pageIndex}_${index}`}
+            value={row.value}
+            component={row.component}
+          />
+        )
       }));
     };
 
-    setPages(_pages.map((page, index) => {
-      const rows = getRows(page, index);
-      return rows.length > 0 ? { ...page, rows } : null;
-    }).filter(p => !!p));
+    setPages(
+      _pages
+        .map((page, index) => {
+          const rows = getRows(page, index);
+          return rows.length > 0 ? { ...page, rows } : null;
+        })
+        .filter((p) => !!p)
+    );
   }, [_pages, onRowAction, setPages]);
 
   const listMarginBottom = hide_page_titles ? 0 : DEFAULT_MARGIN_BOTTOM;
   const isLastPage = (index) => {
-    return index === pages.length -1;
+    return index === pages.length - 1;
   };
 
   const onError = (errors) => {
@@ -53,21 +71,39 @@ const CheckYourAnswers = ({
 
   return (
     <div className={DEFAULT_CLASS}>
-      {title && <LargeHeading key="heading">{title}</LargeHeading>}
+      {title && !hide_title && (
+        <LargeHeading key='heading'>{title}</LargeHeading>
+      )}
       {errors && errors.length > 0 && <ErrorSummary errors={errors} />}
-      {pages && pages.map((page, pageIndex) => {
-        const pageMarginBottom = isLastPage(pageIndex) ? DEFAULT_MARGIN_BOTTOM : listMarginBottom;
-        const className = `govuk-!-margin-bottom-${pageMarginBottom}`;
-        return (
-          <Fragment key={pageIndex}>
-            {!hide_page_titles && page.title && <MediumHeading>{page.title}</MediumHeading>}
-            <SummaryList className={className} rows={page.rows} />
-          </Fragment>
-        );
-      })}
-      {!hide_actions && <PageActions actions={actions} onAction={(action) => onAction(action, onError)} />}
+      {pages &&
+        pages.map((page, pageIndex) => {
+          const pageMarginBottom = isLastPage(pageIndex)
+            ? DEFAULT_MARGIN_BOTTOM
+            : listMarginBottom;
+          const className = `govuk-!-margin-bottom-${pageMarginBottom}`;
+          return (
+            <Fragment key={pageIndex}>
+              {!hide_page_titles && page.title && (
+                <MediumHeading>{page.title}</MediumHeading>
+              )}
+              <SummaryList
+                className={className}
+                rows={page.rows}
+                classModifiers={summaryListClassModifiers}
+                noAction={noAction}
+                invertWeight={invertWeight}
+              />
+            </Fragment>
+          );
+        })}
+      {!hide_actions && (
+        <PageActions
+          actions={actions}
+          onAction={(action) => onAction(action, onError)}
+        />
+      )}
     </div>
-  )
+  );
 };
 
 CheckYourAnswers.propTypes = {
@@ -77,13 +113,21 @@ CheckYourAnswers.propTypes = {
   onAction: PropTypes.func.isRequired,
   onRowAction: PropTypes.func.isRequired,
   hide_page_titles: PropTypes.bool,
-  hide_actions: PropTypes.bool
+  hide_actions: PropTypes.bool,
+  hide_title: PropTypes.bool,
+  summaryListClassModifiers: PropTypes.string,
+  noAction: PropTypes.bool,
+  invertWeight: PropTypes.bool
 };
 
 CheckYourAnswers.defaultProps = {
   title: DEFAULT_TITLE,
   hide_page_titles: false,
-  hide_actions: false
+  hide_actions: false,
+  hide_title: false,
+  summaryListClassModifiers: null,
+  noAction: false,
+  invertWeight:false
 };
 
 export default CheckYourAnswers;

--- a/src/components/CheckYourAnswers/CheckYourAnswers.jsx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.jsx
@@ -29,8 +29,7 @@ const CheckYourAnswers = ({
   hide_actions,
   hide_title,
   summaryListClassModifiers,
-  noAction,
-  invertWeight
+  noChangeAction,
 }) => {
   const [pages, setPages] = useState([]);
   const [errors, setErrors] = useState([]);
@@ -90,8 +89,7 @@ const CheckYourAnswers = ({
                 className={className}
                 rows={page.rows}
                 classModifiers={summaryListClassModifiers}
-                noAction={noAction}
-                invertWeight={invertWeight}
+                noChangeAction={noChangeAction}
               />
             </Fragment>
           );
@@ -115,9 +113,11 @@ CheckYourAnswers.propTypes = {
   hide_page_titles: PropTypes.bool,
   hide_actions: PropTypes.bool,
   hide_title: PropTypes.bool,
-  summaryListClassModifiers: PropTypes.string,
-  noAction: PropTypes.bool,
-  invertWeight: PropTypes.bool
+  summaryListClassModifiers: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  noChangeAction: PropTypes.bool,
 };
 
 CheckYourAnswers.defaultProps = {
@@ -126,8 +126,7 @@ CheckYourAnswers.defaultProps = {
   hide_actions: false,
   hide_title: false,
   summaryListClassModifiers: null,
-  noAction: false,
-  invertWeight:false
+  noChangeAction: false,
 };
 
 export default CheckYourAnswers;

--- a/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
@@ -1,27 +1,27 @@
 <!-- Global imports -->
 
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import {
   Details,
   Heading,
   Link,
   Tag,
-} from "@ukhomeoffice/cop-react-components";
-import withMock from "storybook-addon-mock";
+} from '@ukhomeoffice/cop-react-components';
+import withMock from 'storybook-addon-mock';
 
 <!-- Local imports -->
 
-import Utils from "../../utils";
-import CheckYourAnswers from "./CheckYourAnswers";
+import Utils from '../../utils';
+import CheckYourAnswers from './CheckYourAnswers';
 
 <!-- JSON documents -->
 
-import CIVIL_SERVANT from "../../json/areYouACivilServant.json";
-import GRADE from "../../json/grade.json";
-import TEAMS from "../../json/team.json";
-import USER_PROFILE_DATA from "../../json/userProfile.data.json";
-import USER_PROFILE from "../../json/userProfile.json";
-import FIRST_FORM from "../../json/firstForm.json";
+import CIVIL_SERVANT from '../../json/areYouACivilServant.json';
+import GRADE from '../../json/grade.json';
+import TEAMS from '../../json/team.json';
+import USER_PROFILE_DATA from '../../json/userProfile.data.json';
+import USER_PROFILE from '../../json/userProfile.json';
+import FIRST_FORM from '../../json/firstForm.json';
 
 <Meta
   title='Components/Check your answers'
@@ -43,19 +43,19 @@ Renders the **Check your answers** screen for a form.
       mockData: [
         {
           url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: CIVIL_SERVANT,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: GRADE,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/team`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: TEAMS,
         },
@@ -74,10 +74,10 @@ Renders the **Check your answers** screen for a form.
         { ...DATA }
       );
       const ON_ACTION = (action, patch, onError) => {
-        console.log("action invoked", action, patch);
+        console.log('action invoked', action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log("row action invoked", page);
+        console.log('row action invoked', page);
       };
       return (
         <CheckYourAnswers
@@ -105,19 +105,19 @@ Renders the **Check your answers** screen for a form.
       mockData: [
         {
           url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: CIVIL_SERVANT,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: GRADE,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/team`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: TEAMS,
         },
@@ -136,10 +136,10 @@ Renders the **Check your answers** screen for a form.
         { ...DATA }
       );
       const ON_ACTION = (action, patch, onError) => {
-        console.log("action invoked", action, patch);
+        console.log('action invoked', action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log("row action invoked", page);
+        console.log('row action invoked', page);
       };
       return (
         <CheckYourAnswers
@@ -162,19 +162,19 @@ Renders the **Check your answers** screen for a form.
       mockData: [
         {
           url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: CIVIL_SERVANT,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: GRADE,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/team`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: TEAMS,
         },
@@ -182,7 +182,7 @@ Renders the **Check your answers** screen for a form.
     }}
   >
     {() => {
-      const DATA = { firstName: "John", surname: "Smith", age: 41 };
+      const DATA = { firstName: 'John', surname: 'Smith', age: 41 };
       const PAGES = Utils.FormPage.getAll(
         FIRST_FORM.pages,
         FIRST_FORM.components,
@@ -190,10 +190,10 @@ Renders the **Check your answers** screen for a form.
       );
       const ACTIONS = FIRST_FORM.cya.actions;
       const ON_ACTION = (action, patch, onError) => {
-        console.log("action invoked", action, patch);
+        console.log('action invoked', action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log("row action invoked", page);
+        console.log('row action invoked', page);
       };
       return (
         <CheckYourAnswers
@@ -217,19 +217,19 @@ Renders the **Check your answers** screen for a form.
       mockData: [
         {
           url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: CIVIL_SERVANT,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: GRADE,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/team`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: TEAMS,
         },
@@ -248,10 +248,10 @@ Renders the **Check your answers** screen for a form.
         { ...DATA }
       );
       const ON_ACTION = (action, patch, onError) => {
-        console.log("action invoked", action, patch);
+        console.log('action invoked', action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log("row action invoked", page);
+        console.log('row action invoked', page);
       };
       return (
         <CheckYourAnswers

--- a/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
@@ -1,106 +1,153 @@
 <!-- Global imports -->
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Details, Heading, Link, Tag } from '@ukhomeoffice/cop-react-components';
-import withMock from 'storybook-addon-mock';
+
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import {
+  Details,
+  Heading,
+  Link,
+  Tag,
+} from "@ukhomeoffice/cop-react-components";
+import withMock from "storybook-addon-mock";
 
 <!-- Local imports -->
-import Utils from '../../utils';
-import CheckYourAnswers from './CheckYourAnswers';
+
+import Utils from "../../utils";
+import CheckYourAnswers from "./CheckYourAnswers";
 
 <!-- JSON documents -->
-import CIVIL_SERVANT from '../../json/areYouACivilServant.json';
-import GRADE from '../../json/grade.json';
-import TEAMS from '../../json/team.json';
-import USER_PROFILE_DATA from '../../json/userProfile.data.json';
-import USER_PROFILE from '../../json/userProfile.json';
-import FIRST_FORM from '../../json/firstForm.json';
 
-<Meta title="Components/Check your answers" id="D-CheckYourAnswers" component={ CheckYourAnswers } decorators={[withMock]} />
+import CIVIL_SERVANT from "../../json/areYouACivilServant.json";
+import GRADE from "../../json/grade.json";
+import TEAMS from "../../json/team.json";
+import USER_PROFILE_DATA from "../../json/userProfile.data.json";
+import USER_PROFILE from "../../json/userProfile.json";
+import FIRST_FORM from "../../json/firstForm.json";
 
-<Heading size="xl" caption="Components">Check your answers</Heading>
+<Meta
+  title='Components/Check your answers'
+  id='D-CheckYourAnswers'
+  component={CheckYourAnswers}
+  decorators={[withMock]}
+/>
+
+<Heading size='xl' caption='Components'>
+  Check your answers
+</Heading>
 
 Renders the **Check your answers** screen for a form.
 
 <Canvas withToolbar>
-  <Story name="Default" parameters={{
-    mockData: [
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-        method: 'GET',
-        status: 200,
-        response: CIVIL_SERVANT
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-        method: 'GET',
-        status: 200,
-        response: GRADE
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/team`,
-        method: 'GET',
-        status: 200,
-        response: TEAMS
-      }
-    ]
-  }}>
+  <Story
+    name='Default'
+    parameters={{
+      mockData: [
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+          method: "GET",
+          status: 200,
+          response: CIVIL_SERVANT,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+          method: "GET",
+          status: 200,
+          response: GRADE,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/team`,
+          method: "GET",
+          status: 200,
+          response: TEAMS,
+        },
+      ],
+    }}
+  >
     {() => {
-      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA);
-      const PAGES = Utils.FormPage.getAll(USER_PROFILE.pages, USER_PROFILE.components, { ...DATA });
+      const DATA = Utils.Data.setupForm(
+        USER_PROFILE.pages,
+        USER_PROFILE.components,
+        USER_PROFILE_DATA
+      );
+      const PAGES = Utils.FormPage.getAll(
+        USER_PROFILE.pages,
+        USER_PROFILE.components,
+        { ...DATA }
+      );
       const ON_ACTION = (action, patch, onError) => {
-        console.log('action invoked', action, patch);
+        console.log("action invoked", action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log('row action invoked', page);
+        console.log("row action invoked", page);
       };
       return (
-        <CheckYourAnswers pages={PAGES} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
+        <CheckYourAnswers
+          pages={PAGES}
+          onAction={ON_ACTION}
+          onRowAction={ON_ROW_ACTION}
+        />
       );
     }}
   </Story>
 </Canvas>
 
-<Details summary="Properties" className="no-indent">
-  <ArgsTable of={ CheckYourAnswers } />
+<Details summary='Properties' className='no-indent'>
+  <ArgsTable of={CheckYourAnswers} />
 </Details>
 
 ## Variant
+
 ### Without page titles
 
 <Canvas>
-  <Story name="No page titles" parameters={{
-    mockData: [
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-        method: 'GET',
-        status: 200,
-        response: CIVIL_SERVANT
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-        method: 'GET',
-        status: 200,
-        response: GRADE
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/team`,
-        method: 'GET',
-        status: 200,
-        response: TEAMS
-      }
-    ]
-  }}>
+  <Story
+    name='No page titles'
+    parameters={{
+      mockData: [
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+          method: "GET",
+          status: 200,
+          response: CIVIL_SERVANT,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+          method: "GET",
+          status: 200,
+          response: GRADE,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/team`,
+          method: "GET",
+          status: 200,
+          response: TEAMS,
+        },
+      ],
+    }}
+  >
     {() => {
-      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA);
-      const PAGES = Utils.FormPage.getAll(USER_PROFILE.pages, USER_PROFILE.components, { ...DATA });
+      const DATA = Utils.Data.setupForm(
+        USER_PROFILE.pages,
+        USER_PROFILE.components,
+        USER_PROFILE_DATA
+      );
+      const PAGES = Utils.FormPage.getAll(
+        USER_PROFILE.pages,
+        USER_PROFILE.components,
+        { ...DATA }
+      );
       const ON_ACTION = (action, patch, onError) => {
-        console.log('action invoked', action, patch);
+        console.log("action invoked", action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log('row action invoked', page);
+        console.log("row action invoked", page);
       };
       return (
-        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION}  />
+        <CheckYourAnswers
+          pages={PAGES}
+          hide_page_titles={true}
+          onAction={ON_ACTION}
+          onRowAction={ON_ROW_ACTION}
+        />
       );
     }}
   </Story>
@@ -109,82 +156,113 @@ Renders the **Check your answers** screen for a form.
 ### With actions
 
 <Canvas>
-  <Story name="With actions" parameters={{
-    mockData: [
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-        method: 'GET',
-        status: 200,
-        response: CIVIL_SERVANT
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-        method: 'GET',
-        status: 200,
-        response: GRADE
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/team`,
-        method: 'GET',
-        status: 200,
-        response: TEAMS
-      }
-    ]
-  }}>
+  <Story
+    name='With actions'
+    parameters={{
+      mockData: [
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+          method: "GET",
+          status: 200,
+          response: CIVIL_SERVANT,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+          method: "GET",
+          status: 200,
+          response: GRADE,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/team`,
+          method: "GET",
+          status: 200,
+          response: TEAMS,
+        },
+      ],
+    }}
+  >
     {() => {
-      const DATA = { firstName: 'John', surname: 'Smith', age: 41 };
-      const PAGES = Utils.FormPage.getAll(FIRST_FORM.pages, FIRST_FORM.components, { ...DATA });
+      const DATA = { firstName: "John", surname: "Smith", age: 41 };
+      const PAGES = Utils.FormPage.getAll(
+        FIRST_FORM.pages,
+        FIRST_FORM.components,
+        { ...DATA }
+      );
       const ACTIONS = FIRST_FORM.cya.actions;
       const ON_ACTION = (action, patch, onError) => {
-        console.log('action invoked', action, patch);
+        console.log("action invoked", action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log('row action invoked', page);
+        console.log("row action invoked", page);
       };
       return (
-        <CheckYourAnswers pages={PAGES} hide_page_titles={true} actions={ACTIONS} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
+        <CheckYourAnswers
+          pages={PAGES}
+          hide_page_titles={true}
+          actions={ACTIONS}
+          onAction={ON_ACTION}
+          onRowAction={ON_ROW_ACTION}
+        />
       );
     }}
   </Story>
 </Canvas>
 
-
 ### Read-only style
 
 <Canvas>
-  <Story name="Read-only style" parameters={{
-    mockData: [
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-        method: 'GET',
-        status: 200,
-        response: CIVIL_SERVANT
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-        method: 'GET',
-        status: 200,
-        response: GRADE
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/team`,
-        method: 'GET',
-        status: 200,
-        response: TEAMS
-      }
-    ]
-  }}>
+  <Story
+    name='Read-only style'
+    parameters={{
+      mockData: [
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+          method: "GET",
+          status: 200,
+          response: CIVIL_SERVANT,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+          method: "GET",
+          status: 200,
+          response: GRADE,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/team`,
+          method: "GET",
+          status: 200,
+          response: TEAMS,
+        },
+      ],
+    }}
+  >
     {() => {
-      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA);
-      const PAGES = Utils.FormPage.getAll(USER_PROFILE.pages, USER_PROFILE.components, { ...DATA });
+      const DATA = Utils.Data.setupForm(
+        USER_PROFILE.pages,
+        USER_PROFILE.components,
+        USER_PROFILE_DATA
+      );
+      const PAGES = Utils.FormPage.getAll(
+        USER_PROFILE.pages,
+        USER_PROFILE.components,
+        { ...DATA }
+      );
       const ON_ACTION = (action, patch, onError) => {
-        console.log('action invoked', action, patch);
+        console.log("action invoked", action, patch);
       };
       const ON_ROW_ACTION = (page) => {
-        console.log('row action invoked', page);
+        console.log("row action invoked", page);
       };
       return (
-        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION}  hide_title={true} summaryListClassModifiers='no-border' noAction={true} invertWeight={true}/>
+        <CheckYourAnswers
+          pages={PAGES}
+          hide_page_titles={true}
+          onAction={ON_ACTION}
+          onRowAction={ON_ROW_ACTION}
+          hide_title={true}
+          summaryListClassModifiers='no-border'
+          noChangeAction={true}
+        />
       );
     }}
   </Story>

--- a/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.stories.mdx
@@ -100,7 +100,7 @@ Renders the **Check your answers** screen for a form.
         console.log('row action invoked', page);
       };
       return (
-        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
+        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION}  />
       );
     }}
   </Story>
@@ -143,6 +143,48 @@ Renders the **Check your answers** screen for a form.
       };
       return (
         <CheckYourAnswers pages={PAGES} hide_page_titles={true} actions={ACTIONS} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION} />
+      );
+    }}
+  </Story>
+</Canvas>
+
+
+### Read-only style
+
+<Canvas>
+  <Story name="Read-only style" parameters={{
+    mockData: [
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+        method: 'GET',
+        status: 200,
+        response: CIVIL_SERVANT
+      },
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+        method: 'GET',
+        status: 200,
+        response: GRADE
+      },
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/team`,
+        method: 'GET',
+        status: 200,
+        response: TEAMS
+      }
+    ]
+  }}>
+    {() => {
+      const DATA = Utils.Data.setupForm(USER_PROFILE.pages, USER_PROFILE.components, USER_PROFILE_DATA);
+      const PAGES = Utils.FormPage.getAll(USER_PROFILE.pages, USER_PROFILE.components, { ...DATA });
+      const ON_ACTION = (action, patch, onError) => {
+        console.log('action invoked', action, patch);
+      };
+      const ON_ROW_ACTION = (page) => {
+        console.log('row action invoked', page);
+      };
+      return (
+        <CheckYourAnswers pages={PAGES} hide_page_titles={true} onAction={ON_ACTION} onRowAction={ON_ROW_ACTION}  hide_title={true} summaryListClassModifiers='no-border' noAction={true} invertWeight={true}/>
       );
     }}
   </Story>

--- a/src/components/CheckYourAnswers/CheckYourAnswers.test.js
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.test.js
@@ -129,6 +129,17 @@ describe('components', () => {
       checkRow(status, 'Are you a civil servant?', 'Yes', true);
     });
 
+    it('should show no title if is set to hidden', async () => {
+      await act(async () => {
+        render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_title={true}/>, container);
+      });
+      const cya = checkCYA(container);
+      const title = cya.childNodes[0];
+      expect(title.classList).not.toContain('govuk-heading-l');
+      expect(title.textContent).not.toEqual(DEFAULT_TITLE);
+    });
+
+
   });
 
 });

--- a/src/components/CheckYourAnswers/CheckYourAnswers.test.js
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.test.js
@@ -134,9 +134,12 @@ describe('components', () => {
         render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_title={true}/>, container);
       });
       const cya = checkCYA(container);
-      const title = cya.childNodes[0];
-      expect(title.classList).not.toContain('govuk-heading-l');
-      expect(title.textContent).not.toEqual(DEFAULT_TITLE);
+      const [ names ] = cya.childNodes;
+      expect(names.tagName).toEqual('DL');
+      expect(names.classList).toContain(`govuk-!-margin-bottom-${DEFAULT_MARGIN_BOTTOM}`);
+      const [ firstName, surname ] = names.childNodes;
+      checkRow(firstName, 'First name', 'John', false);
+      checkRow(surname, 'Last name', 'Smith', false);
     });
 
 

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -30,8 +30,7 @@ const FormRenderer = ({
   className,
   hide_title,
   summaryListClassModifiers,
-  noAction,
-  invertWeight
+  noChangeAction,
 }) => {
   // Set up the initial states.
   const [data, setData] = useState({});
@@ -159,8 +158,7 @@ const FormRenderer = ({
           onRowAction={onCYARowAction}
           summaryListClassModifiers={summaryListClassModifiers}
           hide_title={hide_title}
-          noAction={noAction}
-          invertWeight={invertWeight}
+          noChangeAction={noChangeAction}
         />
       }
       {formState.page && <FormPage page={formState.page} onAction={onPageAction} />}
@@ -187,9 +185,11 @@ FormRenderer.propTypes = {
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string,
   hide_title: PropTypes.bool,
-  summaryListClassModifiers: PropTypes.string,
-  noAction: PropTypes.bool,
-  invertWeight: PropTypes.bool
+  summaryListClassModifiers: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  noChangeAction: PropTypes.bool,
 };
 
 FormRenderer.defaultProps = {
@@ -199,9 +199,8 @@ FormRenderer.defaultProps = {
   classBlock: DEFAULT_CLASS,
   classModifiers: [],
   hide_title: false,
-  summaryListClassModifiers: null,
-  noAction: false,
-  invertWeight:false
+  summaryListClassModifiers: [],
+  noChangeAction: false,
 };
 
 export default FormRenderer;

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -27,7 +27,11 @@ const FormRenderer = ({
   hooks: _hooks,
   classBlock,
   classModifiers,
-  className
+  className,
+  hide_title,
+  summaryListClassModifiers,
+  noAction,
+  invertWeight
 }) => {
   // Set up the initial states.
   const [data, setData] = useState({});
@@ -144,7 +148,7 @@ const FormRenderer = ({
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
     <div className={classes()}>
-      {title && pageId === FormPages.HUB && <LargeHeading>{title}</LargeHeading>}
+      {title && !hide_title && pageId === FormPages.HUB && <LargeHeading>{title}</LargeHeading>}
       {
         formState.cya &&
         <CheckYourAnswers
@@ -153,6 +157,10 @@ const FormRenderer = ({
           {...formState.cya}
           onAction={onCYAAction}
           onRowAction={onCYARowAction}
+          summaryListClassModifiers={summaryListClassModifiers}
+          hide_title={hide_title}
+          noAction={noAction}
+          invertWeight={invertWeight}
         />
       }
       {formState.page && <FormPage page={formState.page} onAction={onPageAction} />}
@@ -177,7 +185,11 @@ FormRenderer.propTypes = {
   }),
   classBlock: PropTypes.string,
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-  className: PropTypes.string
+  className: PropTypes.string,
+  hide_title: PropTypes.bool,
+  summaryListClassModifiers: PropTypes.string,
+  noAction: PropTypes.bool,
+  invertWeight: PropTypes.bool
 };
 
 FormRenderer.defaultProps = {
@@ -185,7 +197,11 @@ FormRenderer.defaultProps = {
   components: [],
   pages: [],
   classBlock: DEFAULT_CLASS,
-  classModifiers: []
+  classModifiers: [],
+  hide_title: false,
+  summaryListClassModifiers: null,
+  noAction: false,
+  invertWeight:false
 };
 
 export default FormRenderer;

--- a/src/components/FormRenderer/FormRenderer.stories.mdx
+++ b/src/components/FormRenderer/FormRenderer.stories.mdx
@@ -113,3 +113,36 @@ on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describ
     }}
   </Story>
 </Canvas>
+
+## Read-only style
+
+<Canvas>
+  <Story name="Read-only style" parameters={{
+    mockData: [
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+        method: 'GET',
+        status: 200,
+        response: CIVIL_SERVANT
+      },
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+        method: 'GET',
+        status: 200,
+        response: GRADE
+      },
+      {
+        url: `${USER_PROFILE_DATA.urls.refData}/team`,
+        method: 'GET',
+        status: 200,
+        response: TEAMS
+      }
+    ]
+  }}>
+    {() => {
+      return (
+        <FormRenderer {...USER_PROFILE} data={USER_PROFILE_DATA} summaryListClassModifiers='no-border' hide_title={true} noAction={true} invertWeight={true}/>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/FormRenderer/FormRenderer.stories.mdx
+++ b/src/components/FormRenderer/FormRenderer.stories.mdx
@@ -1,29 +1,29 @@
 <!-- Global imports -->
 
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import {
   Button,
   Details,
   Heading,
   Link,
   Panel,
-} from "@ukhomeoffice/cop-react-components";
-import { useState } from "react";
-import withMock from "storybook-addon-mock";
+} from '@ukhomeoffice/cop-react-components';
+import { useState } from 'react';
+import withMock from 'storybook-addon-mock';
 
 <!-- Local imports -->
 
-import { addHook } from "../../hooks/useHooks";
-import FormRenderer from "./FormRenderer";
+import { addHook } from '../../hooks/useHooks';
+import FormRenderer from './FormRenderer';
 
 <!-- JSON documents -->
 
-import CIVIL_SERVANT from "../../json/areYouACivilServant.json";
-import FIRST_FORM from "../../json/firstForm.json";
-import GRADE from "../../json/grade.json";
-import TEAMS from "../../json/team.json";
-import USER_PROFILE_DATA from "../../json/userProfile.data.json";
-import USER_PROFILE from "../../json/userProfile.json";
+import CIVIL_SERVANT from '../../json/areYouACivilServant.json';
+import FIRST_FORM from '../../json/firstForm.json';
+import GRADE from '../../json/grade.json';
+import TEAMS from '../../json/team.json';
+import USER_PROFILE_DATA from '../../json/userProfile.data.json';
+import USER_PROFILE from '../../json/userProfile.json';
 
 <Meta
   title='Components/Form renderer'
@@ -46,19 +46,19 @@ on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describ
       mockData: [
         {
           url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: CIVIL_SERVANT,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: GRADE,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/team`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: TEAMS,
         },
@@ -82,27 +82,27 @@ on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describ
     {() => {
       const [complete, setComplete] = useState(false);
       const [returnLater, setReturnLater] = useState(false);
-      addHook("onRequest", (req) => {
+      addHook('onRequest', (req) => {
         // Do whatever you need to do to the request in here, such as adding an Authorization header.
-        console.log("onRequest hook called");
+        console.log('onRequest hook called');
         return req;
       });
-      addHook("onFormLoad", () => {
-        console.log("onFormLoad called");
+      addHook('onFormLoad', () => {
+        console.log('onFormLoad called');
       });
-      addHook("onFormComplete", () => {
-        console.log("onFormComplete called");
+      addHook('onFormComplete', () => {
+        console.log('onFormComplete called');
         setComplete(true);
       });
-      addHook("onPageChange", (pageId) => {
-        console.log("onPageChange called", pageId);
+      addHook('onPageChange', (pageId) => {
+        console.log('onPageChange called', pageId);
         setReturnLater(!!pageId === false);
       });
-      addHook("onSubmit", (type, payload, onSuccess, onError) => {
+      addHook('onSubmit', (type, payload, onSuccess, onError) => {
         console.log(
-          "onSubmit called of type",
+          'onSubmit called of type',
           type,
-          "called, with the payload",
+          'called, with the payload',
           payload
         );
         onSuccess();
@@ -147,19 +147,19 @@ on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describ
       mockData: [
         {
           url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: CIVIL_SERVANT,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: GRADE,
         },
         {
           url: `${USER_PROFILE_DATA.urls.refData}/team`,
-          method: "GET",
+          method: 'GET',
           status: 200,
           response: TEAMS,
         },

--- a/src/components/FormRenderer/FormRenderer.stories.mdx
+++ b/src/components/FormRenderer/FormRenderer.stories.mdx
@@ -1,88 +1,110 @@
 <!-- Global imports -->
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Button, Details, Heading, Link, Panel } from '@ukhomeoffice/cop-react-components';
-import { useState } from 'react';
-import withMock from 'storybook-addon-mock';
+
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import {
+  Button,
+  Details,
+  Heading,
+  Link,
+  Panel,
+} from "@ukhomeoffice/cop-react-components";
+import { useState } from "react";
+import withMock from "storybook-addon-mock";
 
 <!-- Local imports -->
-import { addHook } from '../../hooks/useHooks';
-import FormRenderer from './FormRenderer';
+
+import { addHook } from "../../hooks/useHooks";
+import FormRenderer from "./FormRenderer";
 
 <!-- JSON documents -->
-import CIVIL_SERVANT from '../../json/areYouACivilServant.json';
-import FIRST_FORM from '../../json/firstForm.json';
-import GRADE from '../../json/grade.json';
-import TEAMS from '../../json/team.json';
-import USER_PROFILE_DATA from '../../json/userProfile.data.json';
-import USER_PROFILE from '../../json/userProfile.json';
 
-<Meta title="Components/Form renderer" id="D-FormRenderer" component={ FormRenderer } decorators={[withMock]} />
+import CIVIL_SERVANT from "../../json/areYouACivilServant.json";
+import FIRST_FORM from "../../json/firstForm.json";
+import GRADE from "../../json/grade.json";
+import TEAMS from "../../json/team.json";
+import USER_PROFILE_DATA from "../../json/userProfile.data.json";
+import USER_PROFILE from "../../json/userProfile.json";
 
-<Heading size="xl" caption="Components">Form renderer</Heading>
+<Meta
+  title='Components/Form renderer'
+  id='D-FormRenderer'
+  component={FormRenderer}
+  decorators={[withMock]}
+/>
+
+<Heading size='xl' caption='Components'>
+  Form renderer
+</Heading>
 
 Renders a form with <Link href="https://ukhomeoffice.github.io/cop-react-components/?path=/docs/d-alert--default-story">COP React components</Link>,
 on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describes which elements are required.
 
 <Canvas withToolbar>
-  <Story name="Default" parameters={{
-    mockData: [
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-        method: 'GET',
-        status: 200,
-        response: CIVIL_SERVANT
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-        method: 'GET',
-        status: 200,
-        response: GRADE
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/team`,
-        method: 'GET',
-        status: 200,
-        response: TEAMS
-      }
-    ]
-  }}>
+  <Story
+    name='Default'
+    parameters={{
+      mockData: [
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+          method: "GET",
+          status: 200,
+          response: CIVIL_SERVANT,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+          method: "GET",
+          status: 200,
+          response: GRADE,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/team`,
+          method: "GET",
+          status: 200,
+          response: TEAMS,
+        },
+      ],
+    }}
+  >
     {() => {
-      return (
-        <FormRenderer {...USER_PROFILE} data={USER_PROFILE_DATA} />
-      );
+      return <FormRenderer {...USER_PROFILE} data={USER_PROFILE_DATA} />;
     }}
   </Story>
 </Canvas>
 
-<Details summary="Properties" className="no-indent">
-  <ArgsTable of={ FormRenderer } />
+<Details summary='Properties' className='no-indent'>
+  <ArgsTable of={FormRenderer} />
 </Details>
 
 ## CYA type
 
 <Canvas>
-  <Story name="CYA">
+  <Story name='CYA'>
     {() => {
       const [complete, setComplete] = useState(false);
       const [returnLater, setReturnLater] = useState(false);
-      addHook('onRequest', (req) => {
+      addHook("onRequest", (req) => {
         // Do whatever you need to do to the request in here, such as adding an Authorization header.
-        console.log('onRequest hook called');
+        console.log("onRequest hook called");
         return req;
       });
-      addHook('onFormLoad', () => {
-        console.log('onFormLoad called');
+      addHook("onFormLoad", () => {
+        console.log("onFormLoad called");
       });
-      addHook('onFormComplete', () => {
-        console.log('onFormComplete called');
+      addHook("onFormComplete", () => {
+        console.log("onFormComplete called");
         setComplete(true);
       });
-      addHook('onPageChange', (pageId) => {
-        console.log('onPageChange called', pageId);
+      addHook("onPageChange", (pageId) => {
+        console.log("onPageChange called", pageId);
         setReturnLater(!!pageId === false);
       });
-      addHook('onSubmit', (type, payload, onSuccess, onError) => {
-        console.log('onSubmit called of type', type, 'called, with the payload', payload);
+      addHook("onSubmit", (type, payload, onSuccess, onError) => {
+        console.log(
+          "onSubmit called of type",
+          type,
+          "called, with the payload",
+          payload
+        );
         onSuccess();
       });
       const reset = () => {
@@ -91,23 +113,25 @@ on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describ
       };
       return (
         <>
-        {!complete && !returnLater && <FormRenderer {...FIRST_FORM} data={{}} />}
-        {complete &&
-          <div>
-            <Panel title="Submission successful">
-              Your submission was successful.
-            </Panel>
-            <Button onClick={() => reset()}>Start again</Button>
-          </div>
-        }
-        {!complete && returnLater &&
-          <div>
-            <Panel title="Saved to return later">
-              You clicked on "Save and return later".
-            </Panel>
-            <Button onClick={() => reset()}>Start again</Button>
-          </div>
-        }
+          {!complete && !returnLater && (
+            <FormRenderer {...FIRST_FORM} data={{}} />
+          )}
+          {complete && (
+            <div>
+              <Panel title='Submission successful'>
+                Your submission was successful.
+              </Panel>
+              <Button onClick={() => reset()}>Start again</Button>
+            </div>
+          )}
+          {!complete && returnLater && (
+            <div>
+              <Panel title='Saved to return later'>
+                You clicked on "Save and return later".
+              </Panel>
+              <Button onClick={() => reset()}>Start again</Button>
+            </div>
+          )}
         </>
       );
     }}
@@ -117,31 +141,40 @@ on the basis of a <Link href="/?path=/docs/f-json-form">JSON</Link> that describ
 ## Read-only style
 
 <Canvas>
-  <Story name="Read-only style" parameters={{
-    mockData: [
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
-        method: 'GET',
-        status: 200,
-        response: CIVIL_SERVANT
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/grade`,
-        method: 'GET',
-        status: 200,
-        response: GRADE
-      },
-      {
-        url: `${USER_PROFILE_DATA.urls.refData}/team`,
-        method: 'GET',
-        status: 200,
-        response: TEAMS
-      }
-    ]
-  }}>
+  <Story
+    name='Read-only style'
+    parameters={{
+      mockData: [
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/areYouACivilServant`,
+          method: "GET",
+          status: 200,
+          response: CIVIL_SERVANT,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/grade`,
+          method: "GET",
+          status: 200,
+          response: GRADE,
+        },
+        {
+          url: `${USER_PROFILE_DATA.urls.refData}/team`,
+          method: "GET",
+          status: 200,
+          response: TEAMS,
+        },
+      ],
+    }}
+  >
     {() => {
       return (
-        <FormRenderer {...USER_PROFILE} data={USER_PROFILE_DATA} summaryListClassModifiers='no-border' hide_title={true} noAction={true} invertWeight={true}/>
+        <FormRenderer
+          {...USER_PROFILE}
+          data={USER_PROFILE_DATA}
+          summaryListClassModifiers='no-border'
+          hide_title={true}
+          noChangeAction={true}
+        />
       );
     }}
   </Story>

--- a/src/components/FormRenderer/FormRenderer.test.js
+++ b/src/components/FormRenderer/FormRenderer.test.js
@@ -227,6 +227,17 @@ describe('components', () => {
       expect(newPageHeading.textContent).toEqual(USER_PROFILE.pages[5].title);
     });
 
+    it('should show no title when hide_title is set to true', async () => {
+      await act(async () => {
+        render(<FormRenderer {...USER_PROFILE} data={USER_PROFILE_DATA} hide_title={true} />, container);
+      });
+      const form = checkForm(container);
+      expect(form.childNodes.length).toEqual(1); //Hub page (= CYA)
+      const hub = form.childNodes[0];
+      expect(hub.tagName).toEqual('DIV');
+      expect(hub.classList).toContain(CYA_DEFAULT_CLASS);
+    });
+
   });
 
 });

--- a/src/components/SummaryList/SummaryList.jsx
+++ b/src/components/SummaryList/SummaryList.jsx
@@ -12,6 +12,8 @@ import './SummaryList.scss';
 export const DEFAULT_CLASS = 'govuk-summary-list';
 const SummaryList = ({
   rows,
+  noAction,
+  invertWeight,
   classBlock,
   classModifiers,
   className,
@@ -19,40 +21,63 @@ const SummaryList = ({
 }) => {
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
-    <dl {...attrs } className={classes()}>
-      {rows.map(row => (
-        <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
-          <dt className={classes('key')}>{row.key}</dt>
-          <dd className={classes('value')}>{row.value}</dd>
-          <dd className={classes('actions')}>
-            {row.action && <RowAction row={row} />}
-          </dd>
-        </div>
-      ))}
+    <dl {...attrs} className={classes()}>
+      {rows.map((row) =>
+        invertWeight ? (
+          <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
+            <dt className={classes('key caseview__key')}>{row.key}</dt>
+            <dd className={classes('value caseview__value')}>{row.value}</dd>
+            {!noAction && (
+              <dd className={classes('actions')}>
+                {row.action && <RowAction row={row} />}
+              </dd>
+            )}
+          </div>
+        ) : (
+          <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
+            <dt className={classes('key')}>{row.key}</dt>
+            <dd className={classes('value')}>{row.value}</dd>
+            {!noAction && (
+              <dd className={classes('actions')}>
+                {row.action && <RowAction row={row} />}
+              </dd>
+            )}
+          </div>
+        )
+      )}
     </dl>
   );
 };
 
 SummaryList.propTypes = {
-  rows: PropTypes.arrayOf(PropTypes.shape({
-    pageId: PropTypes.string.isRequired,
-    fieldId: PropTypes.string.isRequired,
-    key: PropTypes.string.isRequired,
-    value: PropTypes.any,
-    action: PropTypes.shape({
-      page: PropTypes.string,
-      label: PropTypes.string,
-      aria_suffix: PropTypes.string,
-      onAction: PropTypes.func
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      pageId: PropTypes.string.isRequired,
+      fieldId: PropTypes.string.isRequired,
+      key: PropTypes.string.isRequired,
+      value: PropTypes.any,
+      action: PropTypes.shape({
+        page: PropTypes.string,
+        label: PropTypes.string,
+        aria_suffix: PropTypes.string,
+        onAction: PropTypes.func
+      })
     })
-  })).isRequired,
+  ).isRequired,
   classBlock: PropTypes.string,
-  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-  className: PropTypes.string
+  classModifiers: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  className: PropTypes.string,
+  noAction: PropTypes.bool,
+  invertWeight: PropTypes.bool
 };
 
 SummaryList.defaultProps = {
-  classBlock: DEFAULT_CLASS
+  classBlock: DEFAULT_CLASS,
+  noAction: false,
+  invertWeight: false
 };
 
 export default SummaryList;

--- a/src/components/SummaryList/SummaryList.jsx
+++ b/src/components/SummaryList/SummaryList.jsx
@@ -12,8 +12,7 @@ import './SummaryList.scss';
 export const DEFAULT_CLASS = 'govuk-summary-list';
 const SummaryList = ({
   rows,
-  noAction,
-  invertWeight,
+  noChangeAction,
   classBlock,
   classModifiers,
   className,
@@ -22,28 +21,16 @@ const SummaryList = ({
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
     <dl {...attrs} className={classes()}>
-      {rows.map((row) =>
-        invertWeight ? (
-          <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
-            <dt className={classes('key caseview__key')}>{row.key}</dt>
-            <dd className={classes('value caseview__value')}>{row.value}</dd>
-            {!noAction && (
-              <dd className={classes('actions')}>
-                {row.action && <RowAction row={row} />}
-              </dd>
-            )}
-          </div>
-        ) : (
+      {rows.map((row) =>  
           <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
             <dt className={classes('key')}>{row.key}</dt>
             <dd className={classes('value')}>{row.value}</dd>
-            {!noAction && (
+            {!noChangeAction && (
               <dd className={classes('actions')}>
                 {row.action && <RowAction row={row} />}
               </dd>
             )}
-          </div>
-        )
+          </div>     
       )}
     </dl>
   );
@@ -70,14 +57,12 @@ SummaryList.propTypes = {
     PropTypes.arrayOf(PropTypes.string)
   ]),
   className: PropTypes.string,
-  noAction: PropTypes.bool,
-  invertWeight: PropTypes.bool
+  noChangeAction: PropTypes.bool,
 };
 
 SummaryList.defaultProps = {
   classBlock: DEFAULT_CLASS,
-  noAction: false,
-  invertWeight: false
+  noChangeAction: false,
 };
 
 export default SummaryList;

--- a/src/components/SummaryList/SummaryList.scss
+++ b/src/components/SummaryList/SummaryList.scss
@@ -1,9 +1,17 @@
-@import "node_modules/govuk-frontend/govuk/_base";
-@import "node_modules/govuk-frontend/govuk/components/summary-list/_summary-list";
+@import 'node_modules/govuk-frontend/govuk/_base';
+@import 'node_modules/govuk-frontend/govuk/components/summary-list/_summary-list';
 
 .govuk-summary-list__actions {
   .govuk-link {
     color: govuk-colour('blue');
     cursor: pointer;
   }
+}
+
+.caseview__key {
+  font-weight: normal;
+}
+
+.caseview__value {
+  @include govuk-typography-weight-bold;
 }

--- a/src/components/SummaryList/SummaryList.stories.mdx
+++ b/src/components/SummaryList/SummaryList.stories.mdx
@@ -1,12 +1,12 @@
 <!-- Global imports -->
 
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
-import { Details, Heading } from "@ukhomeoffice/cop-react-components";
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Details, Heading } from '@ukhomeoffice/cop-react-components';
 
 <!-- Local imports -->
 
-import Utils from "../../utils";
-import SummaryList from "./SummaryList";
+import Utils from '../../utils';
+import SummaryList from './SummaryList';
 
 <Meta
   title='Components/Summary list'
@@ -25,22 +25,22 @@ display action links.
   <Story name='Default'>
     {() => {
       const onAction = (row) => {
-        console.log("action clicked", row);
+        console.log('action clicked', row);
       };
       const ROWS = [
         {
-          pageId: "p1",
-          fieldId: "forename",
-          key: "Forename(s)",
-          value: "John",
+          pageId: 'p1',
+          fieldId: 'forename',
+          key: 'Forename(s)',
+          value: 'John',
         },
-        { pageId: "p1", fieldId: "surname", key: "Surname", value: "Smith" },
+        { pageId: 'p1', fieldId: 'surname', key: 'Surname', value: 'Smith' },
         {
-          pageId: "p2",
-          fieldId: "dob",
-          key: "Date of birth",
-          value: "29/08/1993",
-          action: { label: "Change", onAction },
+          pageId: 'p2',
+          fieldId: 'dob',
+          key: 'Date of birth',
+          value: '29/08/1993',
+          action: { label: 'Change', onAction },
         },
       ];
       return <SummaryList rows={ROWS} />;
@@ -60,22 +60,22 @@ display action links.
   <Story name='Read-only style'>
     {() => {
       const onAction = (row) => {
-        console.log("action clicked", row);
+        console.log('action clicked', row);
       };
       const ROWS = [
         {
-          pageId: "p1",
-          fieldId: "forename",
-          key: "Forename(s)",
-          value: "John",
+          pageId: 'p1',
+          fieldId: 'forename',
+          key: 'Forename(s)',
+          value: 'John',
         },
-        { pageId: "p1", fieldId: "surname", key: "Surname", value: "Smith" },
+        { pageId: 'p1', fieldId: 'surname', key: 'Surname', value: 'Smith' },
         {
-          pageId: "p2",
-          fieldId: "dob",
-          key: "Date of birth",
-          value: "29/08/1993",
-          action: { label: "Change", onAction },
+          pageId: 'p2',
+          fieldId: 'dob',
+          key: 'Date of birth',
+          value: '29/08/1993',
+          action: { label: 'Change', onAction },
         },
       ];
       return (

--- a/src/components/SummaryList/SummaryList.stories.mdx
+++ b/src/components/SummaryList/SummaryList.stories.mdx
@@ -1,12 +1,12 @@
 <!-- Global imports -->
 
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Details, Heading } from '@ukhomeoffice/cop-react-components';
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Details, Heading } from "@ukhomeoffice/cop-react-components";
 
 <!-- Local imports -->
 
-import Utils from '../../utils';
-import SummaryList from './SummaryList';
+import Utils from "../../utils";
+import SummaryList from "./SummaryList";
 
 <Meta
   title='Components/Summary list'
@@ -25,66 +25,64 @@ display action links.
   <Story name='Default'>
     {() => {
       const onAction = (row) => {
-        console.log('action clicked', row);
+        console.log("action clicked", row);
       };
       const ROWS = [
         {
-          pageId: 'p1',
-          fieldId: 'forename',
-          key: 'Forename(s)',
-          value: 'John'
+          pageId: "p1",
+          fieldId: "forename",
+          key: "Forename(s)",
+          value: "John",
         },
-        { pageId: 'p1', fieldId: 'surname', key: 'Surname', value: 'Smith' },
+        { pageId: "p1", fieldId: "surname", key: "Surname", value: "Smith" },
         {
-          pageId: 'p2',
-          fieldId: 'dob',
-          key: 'Date of birth',
-          value: '29/08/1993',
-          action: { label: 'Change', onAction }
-        }
+          pageId: "p2",
+          fieldId: "dob",
+          key: "Date of birth",
+          value: "29/08/1993",
+          action: { label: "Change", onAction },
+        },
       ];
-      return (
-        <SummaryList rows={ROWS} />
-      );
+      return <SummaryList rows={ROWS} />;
     }}
   </Story>
 </Canvas>
 
-<Details summary="Properties" className="no-indent">
-  <ArgsTable of={ SummaryList } />
+<Details summary='Properties' className='no-indent'>
+  <ArgsTable of={SummaryList} />
 </Details>
 
 ## Variant
+
 ### Read-only style
 
 <Canvas>
   <Story name='Read-only style'>
     {() => {
       const onAction = (row) => {
-        console.log('action clicked', row);
+        console.log("action clicked", row);
       };
       const ROWS = [
         {
-          pageId: 'p1',
-          fieldId: 'forename',
-          key: 'Forename(s)',
-          value: 'John'
+          pageId: "p1",
+          fieldId: "forename",
+          key: "Forename(s)",
+          value: "John",
         },
-        { pageId: 'p1', fieldId: 'surname', key: 'Surname', value: 'Smith' },
+        { pageId: "p1", fieldId: "surname", key: "Surname", value: "Smith" },
         {
-          pageId: 'p2',
-          fieldId: 'dob',
-          key: 'Date of birth',
-          value: '29/08/1993',
-          action: { label: 'Change', onAction }
-        }
+          pageId: "p2",
+          fieldId: "dob",
+          key: "Date of birth",
+          value: "29/08/1993",
+          action: { label: "Change", onAction },
+        },
       ];
       return (
         <SummaryList
           classModifiers='no-border'
           rows={ROWS}
-          noAction={true}
-          invertWeight={true}
+          noChangeAction={true}
         />
       );
     }}

--- a/src/components/SummaryList/SummaryList.stories.mdx
+++ b/src/components/SummaryList/SummaryList.stories.mdx
@@ -1,28 +1,47 @@
 <!-- Global imports -->
+
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { Details, Heading } from '@ukhomeoffice/cop-react-components';
 
 <!-- Local imports -->
+
 import Utils from '../../utils';
 import SummaryList from './SummaryList';
 
-<Meta title="Components/Summary list" id="D-SummaryList" component={ SummaryList } />
+<Meta
+  title='Components/Summary list'
+  id='D-SummaryList'
+  component={SummaryList}
+/>
 
-<Heading size="xl" caption="Components">Summary list</Heading>
+<Heading size='xl' caption='Components'>
+  Summary list
+</Heading>
 
 Renders a list of key-value pairs, most commonly on the **Check your answers** screen, and optionally
 display action links.
 
 <Canvas withToolbar>
-  <Story name="Default">
+  <Story name='Default'>
     {() => {
       const onAction = (row) => {
         console.log('action clicked', row);
       };
       const ROWS = [
-        { pageId: 'p1', fieldId: 'forename', key: 'Forename(s)', value: 'John' },
+        {
+          pageId: 'p1',
+          fieldId: 'forename',
+          key: 'Forename(s)',
+          value: 'John'
+        },
         { pageId: 'p1', fieldId: 'surname', key: 'Surname', value: 'Smith' },
-        { pageId: 'p2', fieldId: 'dob', key: 'Date of birth', value: '29/08/1993', action: { label: 'Change', onAction } },
+        {
+          pageId: 'p2',
+          fieldId: 'dob',
+          key: 'Date of birth',
+          value: '29/08/1993',
+          action: { label: 'Change', onAction }
+        }
       ];
       return (
         <SummaryList rows={ROWS} />
@@ -34,3 +53,40 @@ display action links.
 <Details summary="Properties" className="no-indent">
   <ArgsTable of={ SummaryList } />
 </Details>
+
+## Variant
+### Read-only style
+
+<Canvas>
+  <Story name='Read-only style'>
+    {() => {
+      const onAction = (row) => {
+        console.log('action clicked', row);
+      };
+      const ROWS = [
+        {
+          pageId: 'p1',
+          fieldId: 'forename',
+          key: 'Forename(s)',
+          value: 'John'
+        },
+        { pageId: 'p1', fieldId: 'surname', key: 'Surname', value: 'Smith' },
+        {
+          pageId: 'p2',
+          fieldId: 'dob',
+          key: 'Date of birth',
+          value: '29/08/1993',
+          action: { label: 'Change', onAction }
+        }
+      ];
+      return (
+        <SummaryList
+          classModifiers='no-border'
+          rows={ROWS}
+          noAction={true}
+          invertWeight={true}
+        />
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/SummaryList/SummaryList.test.js
+++ b/src/components/SummaryList/SummaryList.test.js
@@ -6,9 +6,7 @@ import React from 'react';
 import SummaryList, { DEFAULT_CLASS } from './SummaryList';
 
 describe('components', () => {
-
   describe('SummaryList', () => {
-
     const checkSummaryList = (container, id) => {
       const summaryList = getByTestId(container, id);
       expect(summaryList.tagName).toEqual('DL');
@@ -20,14 +18,27 @@ describe('components', () => {
       const row = summaryList.childNodes[index];
       expect(row.tagName).toEqual('DIV');
       expect(row.classList).toContain(`${DEFAULT_CLASS}__row`);
-      const [ key, value, actions ] = row.childNodes;
+      const [key, value, actions] = row.childNodes;
       expect(key.tagName).toEqual('DT');
       expect(key.classList).toContain(`${DEFAULT_CLASS}__key`);
       expect(value.tagName).toEqual('DD');
       expect(value.classList).toContain(`${DEFAULT_CLASS}__value`);
       expect(actions.tagName).toEqual('DD');
       expect(actions.classList).toContain(`${DEFAULT_CLASS}__actions`);
-      return [ key, value, actions ];
+      return [key, value, actions];
+    };
+
+    const checkRowNoActions = (summaryList, index) => {
+      const row = summaryList.childNodes[index];
+      expect(row.tagName).toEqual('DIV');
+      expect(row.classList).toContain(`${DEFAULT_CLASS}__row`);
+      const [key, value, actions] = row.childNodes;
+      expect(key.tagName).toEqual('DT');
+      expect(key.classList).toContain(`${DEFAULT_CLASS}__key`);
+      expect(value.tagName).toEqual('DD');
+      expect(value.classList).toContain(`${DEFAULT_CLASS}__value`);
+
+      return [key, value, actions];
     };
 
     it('should handle an empty rows array', () => {
@@ -52,7 +63,7 @@ describe('components', () => {
       const summaryList = checkSummaryList(container, ID);
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
-        const [ key, value, actions ] = checkRow(summaryList, index);
+        const [key, value, actions] = checkRow(summaryList, index);
         expect(key.textContent).toEqual(row.key);
         expect(value.textContent).toEqual(row.value);
         expect(actions.childNodes.length).toEqual(0);
@@ -63,8 +74,18 @@ describe('components', () => {
       const ID = 'test-id';
       const VALUES = ['Alpha component value', 'Bravo component value'];
       const ROWS = [
-        { pageId: 'p1', fieldId: 'a', key: 'Alpha', value: <div>{VALUES[0]}</div> },
-        { pageId: 'p2', fieldId: 'b', key: 'Bravo', value: <div>{VALUES[1]}</div> }
+        {
+          pageId: 'p1',
+          fieldId: 'a',
+          key: 'Alpha',
+          value: <div>{VALUES[0]}</div>
+        },
+        {
+          pageId: 'p2',
+          fieldId: 'b',
+          key: 'Bravo',
+          value: <div>{VALUES[1]}</div>
+        }
       ];
       const { container } = render(
         <SummaryList data-testid={ID} rows={ROWS} />
@@ -72,7 +93,7 @@ describe('components', () => {
       const summaryList = checkSummaryList(container, ID);
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
-        const [ key, value, actions ] = checkRow(summaryList, index);
+        const [key, value, actions] = checkRow(summaryList, index);
         expect(key.textContent).toEqual(row.key);
         expect(value.childNodes.length).toEqual(1);
         const valueDiv = value.childNodes[0];
@@ -89,8 +110,20 @@ describe('components', () => {
         ON_ACTION_CALLS.push(row);
       };
       const ROWS = [
-        { pageId: 'p1', fieldId: 'a', key: 'Alpha', value: 'Alpha value', action: { label: 'Change A', onAction: ON_ACTION } },
-        { pageId: 'p2', fieldId: 'b', key: 'Bravo', value: 'Bravo value', action: { label: 'Change B', onAction: ON_ACTION } }
+        {
+          pageId: 'p1',
+          fieldId: 'a',
+          key: 'Alpha',
+          value: 'Alpha value',
+          action: { label: 'Change A', onAction: ON_ACTION }
+        },
+        {
+          pageId: 'p2',
+          fieldId: 'b',
+          key: 'Bravo',
+          value: 'Bravo value',
+          action: { label: 'Change B', onAction: ON_ACTION }
+        }
       ];
       const { container } = render(
         <SummaryList data-testid={ID} rows={ROWS} />
@@ -98,7 +131,7 @@ describe('components', () => {
       const summaryList = checkSummaryList(container, ID);
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
-        const [ key, value, actions ] = checkRow(summaryList, index);
+        const [key, value, actions] = checkRow(summaryList, index);
         expect(key.textContent).toEqual(row.key);
         expect(value.textContent).toEqual(row.value);
         const a = actions.childNodes[0];
@@ -109,6 +142,77 @@ describe('components', () => {
       });
     });
 
-  });
+    it('should handle rows with component values and actions set to hidden', () => {
+      const ID = 'test-id';
+      const VALUES = ['Alpha component value', 'Bravo component value'];
+      const ROWS = [
+        {
+          pageId: 'p1',
+          fieldId: 'a',
+          key: 'Alpha',
+          value: <div>{VALUES[0]}</div>
+        },
+        {
+          pageId: 'p2',
+          fieldId: 'b',
+          key: 'Bravo',
+          value: <div>{VALUES[1]}</div>
+        }
+      ];
+      const { container } = render(
+        <SummaryList data-testid={ID} rows={ROWS} noAction={true} />
+      );
+      const summaryList = checkSummaryList(container, ID);
+      expect(summaryList.childNodes.length).toEqual(ROWS.length);
+      ROWS.forEach((row, index) => {
+        const [key, value] = checkRowNoActions(summaryList, index);
+        expect(key.textContent).toEqual(row.key);
+        expect(value.childNodes.length).toEqual(1);
+        const valueDiv = value.childNodes[0];
+        expect(valueDiv.tagName).toEqual('DIV');
+        expect(valueDiv.textContent).toEqual(VALUES[index]);
+      });
+    });
 
+    it('should handle rows with component values and font weights set to inverted', () => {
+      const ID = 'test-id';
+      const ON_ACTION_CALLS = [];
+      const ON_ACTION = (row) => {
+        ON_ACTION_CALLS.push(row);
+      };
+      const ROWS = [
+        {
+          pageId: 'p1',
+          fieldId: 'a',
+          key: 'Alpha',
+          value: 'Alpha value',
+          action: { label: 'Change A', onAction: ON_ACTION }
+        },
+        {
+          pageId: 'p2',
+          fieldId: 'b',
+          key: 'Bravo',
+          value: 'Bravo value',
+          action: { label: 'Change B', onAction: ON_ACTION }
+        }
+      ];
+      const { container } = render(
+        <SummaryList data-testid={ID} rows={ROWS} invertWeight={true} />
+      );
+      const summaryList = checkSummaryList(container, ID);
+      expect(summaryList.childNodes.length).toEqual(ROWS.length);
+      ROWS.forEach((row, index) => {
+        const [key, value, actions] = checkRow(summaryList, index);
+        expect(key.textContent).toEqual(row.key);
+        expect(key.classList).toContain('caseview__key');
+        expect(value.textContent).toEqual(row.value);
+        expect(value.classList).toContain('caseview__value');
+        const a = actions.childNodes[0];
+        expect(a.textContent).toEqual(row.action.label);
+        fireEvent.click(a, {});
+        expect(ON_ACTION_CALLS.length).toEqual(index + 1);
+        expect(ON_ACTION_CALLS[index]).toEqual(row);
+      });
+    });
+  });
 });

--- a/src/components/SummaryList/SummaryList.test.js
+++ b/src/components/SummaryList/SummaryList.test.js
@@ -28,17 +28,17 @@ describe('components', () => {
       return [key, value, actions];
     };
 
-    const checkRowNoActions = (summaryList, index) => {
+    const checkRowNoChangeActions = (summaryList, index) => {
       const row = summaryList.childNodes[index];
       expect(row.tagName).toEqual('DIV');
       expect(row.classList).toContain(`${DEFAULT_CLASS}__row`);
-      const [key, value, actions] = row.childNodes;
+      const [key, value] = row.childNodes;
       expect(key.tagName).toEqual('DT');
       expect(key.classList).toContain(`${DEFAULT_CLASS}__key`);
       expect(value.tagName).toEqual('DD');
       expect(value.classList).toContain(`${DEFAULT_CLASS}__value`);
-
-      return [key, value, actions];
+      expect(row.childNodes.length).toEqual(2);
+      return [key, value];
     };
 
     it('should handle an empty rows array', () => {
@@ -160,58 +160,17 @@ describe('components', () => {
         }
       ];
       const { container } = render(
-        <SummaryList data-testid={ID} rows={ROWS} noAction={true} />
+        <SummaryList data-testid={ID} rows={ROWS} noChangeAction={true} />
       );
       const summaryList = checkSummaryList(container, ID);
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
-        const [key, value] = checkRowNoActions(summaryList, index);
+        const [key, value] = checkRowNoChangeActions(summaryList, index);
         expect(key.textContent).toEqual(row.key);
         expect(value.childNodes.length).toEqual(1);
         const valueDiv = value.childNodes[0];
         expect(valueDiv.tagName).toEqual('DIV');
         expect(valueDiv.textContent).toEqual(VALUES[index]);
-      });
-    });
-
-    it('should handle rows with component values and font weights set to inverted', () => {
-      const ID = 'test-id';
-      const ON_ACTION_CALLS = [];
-      const ON_ACTION = (row) => {
-        ON_ACTION_CALLS.push(row);
-      };
-      const ROWS = [
-        {
-          pageId: 'p1',
-          fieldId: 'a',
-          key: 'Alpha',
-          value: 'Alpha value',
-          action: { label: 'Change A', onAction: ON_ACTION }
-        },
-        {
-          pageId: 'p2',
-          fieldId: 'b',
-          key: 'Bravo',
-          value: 'Bravo value',
-          action: { label: 'Change B', onAction: ON_ACTION }
-        }
-      ];
-      const { container } = render(
-        <SummaryList data-testid={ID} rows={ROWS} invertWeight={true} />
-      );
-      const summaryList = checkSummaryList(container, ID);
-      expect(summaryList.childNodes.length).toEqual(ROWS.length);
-      ROWS.forEach((row, index) => {
-        const [key, value, actions] = checkRow(summaryList, index);
-        expect(key.textContent).toEqual(row.key);
-        expect(key.classList).toContain('caseview__key');
-        expect(value.textContent).toEqual(row.value);
-        expect(value.classList).toContain('caseview__value');
-        const a = actions.childNodes[0];
-        expect(a.textContent).toEqual(row.action.label);
-        fireEvent.click(a, {});
-        expect(ON_ACTION_CALLS.length).toEqual(index + 1);
-        expect(ON_ACTION_CALLS[index]).toEqual(row);
       });
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // Local imports
 import FormRenderer from './components/FormRenderer';
+import SummaryList from './components/SummaryList';
 import { addHook, removeHook, resetHooks } from './hooks/useHooks';
 import { FormTypes, HubFormats } from './models';
 import Utils from './utils';
@@ -13,6 +14,7 @@ const intercepts = {
 export {
   intercepts,
   FormRenderer,
+  SummaryList,
   FormTypes,
   HubFormats,
   Utils


### PR DESCRIPTION
### Description
This change has been done to support changes in cop to display read-only versions of submitted forms when in CaseView. The styling has been applied to match what was outlined in the figma documentation containing the initial designs of CaseView.

https://support.cop.homeoffice.gov.uk/browse/COP-10344

### To test
Testing that the functionality works can be achieved by viewing the changes in storybook (`yarn storybook`) and looking in each of the respected sections for Check Your Answers, Form Renderer and Summary List. At the bottom there will be a read-only view which contains no change actions, or no lines.
