### PR TITLE
COP-10564: Add hook for overriding component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "2.2.0-alpha",
+  "version": "2.2.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/FormComponent/FormComponent.jsx
+++ b/src/components/FormComponent/FormComponent.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 
 // Local imports
+import useHooks from '../../hooks/useHooks';
 import useRefData, { STATUS_COMPLETE } from '../../hooks/useRefData';
 import Utils from '../../utils';
 
@@ -13,6 +14,7 @@ const FormComponent = ({
   onChange,
   ...attrs
 }) => {
+  const { hooks } = useHooks();
   const { data, status } = useRefData(component);
   const [ options, setOptions ] = useState([]);
   useEffect(() => {
@@ -30,6 +32,7 @@ const FormComponent = ({
     value: value || '',
     onChange
   }, wrap);
+  }, wrap, hooks.onGetComponent);
 };
 
 FormComponent.propTypes = {

--- a/src/components/FormComponent/FormComponent.jsx
+++ b/src/components/FormComponent/FormComponent.jsx
@@ -31,7 +31,6 @@ const FormComponent = ({
     options,
     value: value || '',
     onChange
-  }, wrap);
   }, wrap, hooks.onGetComponent);
 };
 

--- a/src/components/FormComponent/FormComponent.test.js
+++ b/src/components/FormComponent/FormComponent.test.js
@@ -3,11 +3,16 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 // Local imports
+import { addHook, resetHooks } from '../../hooks/useHooks';
 import FormComponent from './FormComponent';
 
 describe('components', () => {
 
   describe('FormComponent', () => {
+
+    beforeEach(() => {
+      resetHooks();
+    });
 
     it('should render a text component appropriately', async () => {
       const ID = 'component';
@@ -56,6 +61,34 @@ describe('components', () => {
     });
 
     it('should render an html component appropriately', async () => {
+      const ID = 'component';
+      const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
+      const { container } = render(
+        <FormComponent data-testid={ID} component={COMPONENT} />
+      );
+      const p = container.childNodes[0];
+      expect(p.tagName).toEqual('P');
+      expect(p.textContent).toEqual(COMPONENT.content);
+    });
+
+    it('should render an overridden html component appropriately', async () => {
+      addHook('onGetComponent', (config, wrap) => {
+        return <div>{`${config.type} | ${config.tagName} | ${config.content} | ${wrap}`}</div>
+      });
+      const ID = 'component';
+      const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
+      const { container } = render(
+        <FormComponent data-testid={ID} component={COMPONENT} />
+      );
+      const div = container.childNodes[0];
+      expect(div.tagName).toEqual('DIV');
+      expect(div.textContent).toEqual(`${COMPONENT.type} | ${COMPONENT.tagName} | ${COMPONENT.content} | true`);
+    });
+
+    it('should render the correct html component when the override returns null', async () => {
+      addHook('onGetComponent', () => {
+        return null;
+      });
       const ID = 'component';
       const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
       const { container } = render(

--- a/src/hooks/useHooks.js
+++ b/src/hooks/useHooks.js
@@ -1,8 +1,16 @@
-export const ALLOWED_HOOKS = ['onRequest', 'onFormComplete', 'onFormLoad', 'onPageChange', 'onSubmit'];
+export const ALLOWED_HOOKS = [
+  'onFormComplete',
+  'onFormLoad',
+  'onGetComponent',
+  'onPageChange',
+  'onRequest',
+  'onSubmit'
+];
 
 const DEFAULT_HOOKS = {
   onFormComplete: () => {},
   onFormLoad: () => {},
+  onGetComponent: (config, wrap) => null,
   onPageChange: (pageId) => pageId,
   onRequest: (req) => req,
   onSubmit: (type, payload, onSuccess, onError) => {
@@ -13,6 +21,7 @@ const DEFAULT_HOOKS = {
 const hooks = {
   onFormComplete: DEFAULT_HOOKS.onFormComplete,
   onFormLoad: DEFAULT_HOOKS.onFormLoad,
+  onGetComponent: DEFAULT_HOOKS.onGetComponent,
   onPageChange: DEFAULT_HOOKS.onPageChange,
   onRequest: DEFAULT_HOOKS.onRequest,
   onSubmit: DEFAULT_HOOKS.onSubmit

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -98,7 +98,20 @@ const getComponentByType = (config) => {
   }
 };
 
-const getComponent = (config, wrap = true) => {
+/**
+ * Get a renderable component, based on a configuration object.
+ * @param {object} config The configuration object for the component.
+ * @param {boolean} wrap Indicates whether or not the component should be wrapped.
+ * @param {Function} fnOverride An optional override function for component rendering.
+ * @returns A renderable component.
+ */
+const getComponent = (config, wrap = true, fnOverride = undefined) => {
+  if (typeof fnOverride === 'function') {
+    const overrideComponent = fnOverride(config, wrap);
+    if (overrideComponent) {
+      return overrideComponent;
+    }
+  }
   const component = getComponentByType(config);
   if (component && wrap && isEditable(config)) {
     const attrs = cleanAttributes(config, ['fieldId', 'displayMenu']);


### PR DESCRIPTION
### Descripton
Added a hook for overriding components. The override function is passed the `wrap` parameter where a value of `false` means it _shouldn't_ be wrapped and a value of `true` means the function should decide whether or not it's should be within a `FormGroup` and wrap it if necessary.

https://support.cop.homeoffice.gov.uk/browse/COP-10564

### To test
Covered by accompanying unit tests.