### PR TITLE
Feature/cop 7991 add tasklist navigation to sections

### DIFF
--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -40,7 +40,7 @@ const FormRenderer = ({
   const [hub, setHub] = useState(undefined);
   const [pageId, setPageId] = useState(helpers.getNextPageId(type, _pages));
   const [formState, setFormState] = useState(helpers.getFormState(pageId, pages, hub));
-  const [currentTask, setCurrentTask] = useState(undefined);
+  const [currentTask, setCurrentTask] = useState({});
   // Set up hooks.
   const { hooks, addHook } = useHooks();
   useEffect(() => {
@@ -88,14 +88,16 @@ const FormRenderer = ({
     hooks.onFormLoad();
   }, [hooks]);
 
-  //Update task list pages
+  //Update task list pages with form data
   useEffect(() => {
-    if(currentTask && currentTask.fullPages){
-      currentTask.fullPages.forEach(page => {
-        page.formData = data
-      })
+    const pages = currentTask.fullPages;
+    if(pages){
+      pages.forEach(page => {
+        page.formData = data;
+      });
+      setCurrentTask(prev => ({...prev, fullpages: pages}));
     }
-  } ,[currentTask, data]);
+  } , [currentTask.fullPages, data]);
 
   const onPageChange = (newPageId) => {
     setPageId(newPageId);
@@ -193,7 +195,7 @@ const FormRenderer = ({
       {
         formState.cya &&
         <CheckYourAnswers
-          pages={currentTask ? currentTask.fullPages : pages}
+          pages={currentTask.fullPages ? currentTask.fullPages : pages}
           {...cya}
           {...formState.cya}
           onAction={onCYAAction}

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -186,8 +186,10 @@ const FormRenderer = ({
   };
 
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
-  const cyaAction =
-    hub === HubFormats.TASK ? [{ type: PageAction.TYPES.SAVE_AND_RETURN, label: 'Submit', validate: true }] : undefined;
+
+  if(hub === HubFormats.TASK){
+    cya.actions = [{ type: PageAction.TYPES.SAVE_AND_RETURN, label: 'Submit', validate: true }];
+  }
 
   return (
     <div className={classes()}>
@@ -203,7 +205,6 @@ const FormRenderer = ({
           summaryListClassModifiers={summaryListClassModifiers}
           hide_title={hide_title}
           noChangeAction={noChangeAction}
-          actions={cyaAction}
         />
       }
       {hub === HubFormats.TASK && formState.pageId === FormPages.HUB && (

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -5,11 +5,12 @@ import React, { useEffect, useState } from 'react';
 
 // Local imports
 import { useHooks } from '../../hooks';
-import { EventTypes, FormPages, FormTypes, HubFormats, PageAction } from '../../models';
+import { EventTypes, FormPages, FormTypes, HubFormats, PageAction, TaskStates } from '../../models';
 import Utils from '../../utils';
 import CheckYourAnswers from '../CheckYourAnswers';
 import FormPage from '../FormPage';
 import TaskList from '../TaskList';
+import getPage from './helpers/getPage';
 import handlers from './handlers';
 import helpers from './helpers';
 
@@ -39,7 +40,7 @@ const FormRenderer = ({
   const [hub, setHub] = useState(undefined);
   const [pageId, setPageId] = useState(helpers.getNextPageId(type, _pages));
   const [formState, setFormState] = useState(helpers.getFormState(pageId, pages, hub));
-  
+  const [currentTask, setCurrentTask] = useState(undefined);
   // Set up hooks.
   const { hooks, addHook } = useHooks();
   useEffect(() => {
@@ -87,6 +88,15 @@ const FormRenderer = ({
     hooks.onFormLoad();
   }, [hooks]);
 
+  //Update task list pages
+  useEffect(() => {
+    if(currentTask && currentTask.fullPages){
+      currentTask.fullPages.forEach(page => {
+        page.formData = data
+      })
+    }
+  } ,[currentTask, data]);
+
   const onPageChange = (newPageId) => {
     setPageId(newPageId);
     hooks.onPageChange(newPageId);
@@ -106,12 +116,18 @@ const FormRenderer = ({
         if (patch) {
           setData(submissionData);
         }
+
+        let pageUpdate = (next) => onPageChange(helpers.getNextPageId(type, pages, pageId, action, next));
+        if (action.type === PageAction.TYPES.SAVE_AND_NAVIGATE) {
+          pageUpdate = () => handlers.navigate(action, pageId, onPageChange);
+        }
+
         // Now submit the data to the backend...
         hooks.onSubmit(action.type, submissionData, (response) => {
           // The backend response may well contain data we need so apply it.
           setData(prev => {
             const next = { ...prev, ...response };
-            onPageChange(helpers.getNextPageId(type, pages, pageId, action, next));
+            pageUpdate(next);
             return next;
           });
         }, (errors) => {
@@ -126,9 +142,22 @@ const FormRenderer = ({
     handlers.cyaAction(page, pageId, onPageChange);
   };
 
-  const onTaskAction = (page) => {
-    //TODO Lauch pages for task, covered under COP-7991
-  }
+  //Kick off a task, gather required pages and move to the correct point
+  const onTaskAction = (currentTask) => {
+    if (currentTask) {
+      currentTask.fullPages = [];
+      currentTask.pages.forEach((page) => {
+        currentTask.fullPages.push(getPage(page, pages));
+      });
+      setCurrentTask(currentTask);
+      if(currentTask.state === TaskStates.TYPES.COMPLETE){
+        onPageChange(FormPages.CYA);
+      }
+      else{
+        onPageChange(currentTask.pages[0]);
+      }
+    }
+  };
 
   // Handle actions from "Check your answers".
   const onCYAAction = (action, onError) => {
@@ -147,16 +176,24 @@ const FormRenderer = ({
         );
       }
     }
+    if (action.type === PageAction.TYPES.SAVE_AND_RETURN) {
+      if (helpers.canCYASubmit(currentTask.fullPages, onError)) {
+        onPageChange(FormPages.HUB);
+      }
+    }
   };
 
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
+  const cyaAction =
+    hub === HubFormats.TASK ? [{ type: PageAction.TYPES.SAVE_AND_RETURN, label: 'Submit', validate: true }] : undefined;
+
   return (
     <div className={classes()}>
       {title && !hide_title && pageId === FormPages.HUB && <LargeHeading>{title}</LargeHeading>}
       {
         formState.cya &&
         <CheckYourAnswers
-          pages={pages}
+          pages={currentTask ? currentTask.fullPages : pages}
           {...cya}
           {...formState.cya}
           onAction={onCYAAction}
@@ -164,9 +201,17 @@ const FormRenderer = ({
           summaryListClassModifiers={summaryListClassModifiers}
           hide_title={hide_title}
           noChangeAction={noChangeAction}
+          actions={cyaAction}
         />
       }
-      {hub === HubFormats.TASK && <TaskList sections={_hub.sections} refNumber={data['businessKey']} refTitle={_hub.refTitle} onTaskAction={onTaskAction}/>}
+      {hub === HubFormats.TASK && formState.pageId === FormPages.HUB && (
+        <TaskList
+          sections={_hub.sections}
+          refNumber={data['businessKey']}
+          refTitle={_hub.refTitle}
+          onTaskAction={onTaskAction}
+        />
+      )}
       {formState.page && <FormPage page={formState.page} onAction={onPageAction} />}
     </div>
   );

--- a/src/components/FormRenderer/FormRenderer.test.js
+++ b/src/components/FormRenderer/FormRenderer.test.js
@@ -9,6 +9,7 @@ import { act } from 'react-dom/test-utils';
 // Local imports
 import { PageAction } from '../../models';
 import { DEFAULT_CLASS as CYA_DEFAULT_CLASS } from '../CheckYourAnswers/CheckYourAnswers';
+import { DEFAULT_CLASS as TASK_LIST_DEFAULT_CLASS } from '../TaskList/TaskList';
 import FormRenderer, { DEFAULT_CLASS } from './FormRenderer';
 
 // JSON
@@ -17,6 +18,7 @@ import GRADE from '../../json/grade.json';
 import TEAMS from '../../json/team.json';
 import USER_PROFILE_DATA from '../../json/userProfile.data.json';
 import USER_PROFILE from '../../json/userProfile.json';
+import TASK_LIST from '../../json/taskList.json';
 
 describe('components', () => {
 
@@ -236,6 +238,69 @@ describe('components', () => {
       const hub = form.childNodes[0];
       expect(hub.tagName).toEqual('DIV');
       expect(hub.classList).toContain(CYA_DEFAULT_CLASS);
+    });
+
+    it('should render a tasklist', async () => {
+      await act(async () => {
+        render(<FormRenderer {...TASK_LIST} />, container);
+      });
+      const taskList = container.childNodes[0].childNodes[1];
+      expect(taskList.classList).toContain(TASK_LIST_DEFAULT_CLASS);
+    });
+
+    it('should handle navigating between task list pages', async () => {
+      const ON_SUBMIT = (type, payload, onSuccess, onError) => {
+        onSuccess();
+      };
+      const HOOKS = {
+        onSubmit: ON_SUBMIT
+      };
+
+      await act(async () => {
+        render(<FormRenderer {...TASK_LIST}  hooks={HOOKS}/>, container);
+      });
+
+      //Launch into task 
+      const taskList = container.childNodes[0].childNodes[1];
+      const taskLink = taskList.childNodes[4].childNodes[1].childNodes[0].childNodes[0]
+      expect(taskLink.textContent).toEqual('Officer and agency details')
+      fireEvent.click(taskLink, {});
+
+      //Complete the only page in the task and continue
+      const newPage = container.childNodes[0].childNodes[0];
+      expect(newPage.childNodes[0].textContent).toEqual('Officer Details')
+      const continueButton = newPage.childNodes[2].childNodes[0];
+      fireEvent.click(continueButton, {});
+
+      //Continue on from CYA page
+      expect(container.childNodes[0].childNodes[0].childNodes[0].textContent).toEqual('Check your answers');
+      expect(container.childNodes[0].childNodes[0].childNodes[3].textContent).toEqual('Submit');
+      fireEvent.click(container.childNodes[0].childNodes[0].childNodes[3].childNodes[0], {});
+
+      //Should be back at task list
+      expect(container.childNodes[0].childNodes[0].textContent).toEqual('Event at the border');
+    });
+
+    it('should go straight to CYA page if a complete task is selected', async () => {
+      const ON_SUBMIT = (type, payload, onSuccess, onError) => {
+        onSuccess();
+      };
+      const HOOKS = {
+        onSubmit: ON_SUBMIT
+      };
+
+      await act(async () => {
+        render(<FormRenderer {...TASK_LIST}  hooks={HOOKS}/>, container);
+      });
+
+      //Launch into task with complete state
+      const taskList = container.childNodes[0].childNodes[1];
+      const taskLink = taskList.childNodes[4].childNodes[0].childNodes[0].childNodes[0]
+      expect(taskLink.textContent).toEqual('Date, location and mode details')
+      fireEvent.click(taskLink, {});
+
+      //Should be at CYA page
+      expect(container.childNodes[0].childNodes[0].childNodes[0].textContent).toEqual('Check your answers');
     });
 
   });

--- a/src/components/TaskList/Task.jsx
+++ b/src/components/TaskList/Task.jsx
@@ -23,7 +23,7 @@ const Task = ({ task, onClick }) => {
   return (
     <li className={classes('item')}>
       <span className={classes('task-name')}>
-        {linkActive ? <Link onClick={() => onClick(task.firstPage)}>{task.name}</Link> : task.name}
+        {linkActive ? <Link onClick={() => onClick(task)}>{task.name}</Link> : task.name}
       </span>
       <TaskState state={currentState} />
     </li>
@@ -33,7 +33,7 @@ const Task = ({ task, onClick }) => {
 Task.propTypes = {
   task: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    firstPage: PropTypes.string.isRequired,
+    pages: PropTypes.array.isRequired,
     state: PropTypes.string.isRequired,
   }).isRequired,
   onClick: PropTypes.func.isRequired,

--- a/src/components/TaskList/Task.test.js
+++ b/src/components/TaskList/Task.test.js
@@ -10,7 +10,7 @@ describe('components', () => {
   describe('TaskList.Task', () => {
     it('should render a task', () => {
       const STATE = TaskStates.TYPES.COMPLETE;
-      const TASK = { name: 'taskName', firstPage: 'pageName', state: STATE };
+      const TASK = { name: 'taskName', pages: ['pageName'], state: STATE };
       const ON_CLICK = () => {};
       const { container } = render(<Task task={TASK} onClick={ON_CLICK} />);
       expect(container.childNodes.length).toEqual(1);
@@ -25,7 +25,7 @@ describe('components', () => {
     it('should render a task with inactive link if state is cannotStartYet', () => {
       const NAME = 'taskName';
       const STATE =  TaskStates.TYPES.CANNOT_START_YET;
-      const TASK = { name: 'taskName', firstPage: 'pageName', state: STATE };
+      const TASK = { name: 'taskName', pages: ['pageName'], state: STATE };
       const ON_CLICK = () => {};
       const { container } = render(<Task task={TASK} onClick={ON_CLICK} />);
       const span = container.childNodes[0].childNodes[0];
@@ -35,7 +35,7 @@ describe('components', () => {
 
     it('should render a task with a link if state is not cannotStartYet', () => {
       const STATE =  TaskStates.TYPES.IN_PROGRESS;
-      const TASK = { name: 'taskName', firstPage: 'pageName', state: STATE };
+      const TASK = { name: 'taskName', pages: ['pageName'], state: STATE };
       const ON_CLICK = () => {};
       const { container } = render(<Task task={TASK} onClick={ON_CLICK} />);
       const span = container.childNodes[0].childNodes[0];
@@ -45,7 +45,7 @@ describe('components', () => {
 
     it('should call then given onClick function when the link is clicked', () => {
       const STATE =  TaskStates.TYPES.IN_PROGRESS;
-      const TASK = { name: 'taskName', firstPage: 'pageName', state: STATE };
+      const TASK = { name: 'taskName', pages: ['pageName'], state: STATE };
       const ON_CLICK_CALLS = [];
       const ON_CLICK = (value) => {
         ON_CLICK_CALLS.push(value);
@@ -55,7 +55,7 @@ describe('components', () => {
       fireEvent.click(link);
 
       expect(ON_CLICK_CALLS.length).toEqual(1);
-      expect(ON_CLICK_CALLS[0]).toEqual('pageName');
+      expect(ON_CLICK_CALLS[0]).toEqual({ pages: ['pageName'], name: "taskName", state: STATE});
     });
   });
 });

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -23,9 +23,9 @@ const TaskList = ({ refTitle, refNumber, sections, fieldId, onTaskAction, classB
     return totalSections + current.tasks.length;
   }, 0);
 
-  const onClick = (firstPage) => {
+  const onClick = (task) => {
     if (typeof onTaskAction === 'function') {
-      onTaskAction(firstPage);
+      onTaskAction(task);
     }
   };
 
@@ -64,7 +64,7 @@ TaskList.propTypes = {
       tasks: PropTypes.arrayOf(
         PropTypes.shape({
           name: PropTypes.string.isRequired,
-          firstPage: PropTypes.string.isRequired,
+          pages: PropTypes.array.isRequired,
           state: PropTypes.string.isRequired,
         })
       ).isRequired,

--- a/src/components/TaskList/TaskList.scss
+++ b/src/components/TaskList/TaskList.scss
@@ -48,6 +48,7 @@
 
 .hods-task-list__task-name {
   display: block;
+  cursor: pointer;
   @include govuk-media-query($from: 450px) {
     float: left;
   }

--- a/src/components/TaskList/TaskList.test.js
+++ b/src/components/TaskList/TaskList.test.js
@@ -14,17 +14,17 @@ describe('components', () => {
         {
           name: 'These are your tasks',
           tasks: [
-            { name: 'Nice task', state: 'complete', firstPage: 'pageOne' },
-            { name: 'Ok task', state: 'inProgress', firstPage: 'pageTwo' },
-            { name: 'Terrible task', state: 'notStarted', firstPage: 'pageThree' },
+            { name: 'Nice task', state: 'complete', pages: ['pageOne'] },
+            { name: 'Ok task', state: 'inProgress', pages: ['pageTwo'] },
+            { name: 'Terrible task', state: 'notStarted', pages: ['pageThree'] },
           ],
         },
         {
           name: 'These are your extra bonus tasks',
           tasks: [
-            { name: 'Nice task', state: 'complete', firstPage: 'pageFour' },
-            { name: 'Ok task', state: 'cannotStartYet', firstPage: 'pageFive' },
-            { name: 'Terrible task', state: 'cannotStartYet', firstPage: 'pageSix' },
+            { name: 'Nice task', state: 'complete', pages: ['pageFour'] },
+            { name: 'Ok task', state: 'cannotStartYet', pages: ['pageFive'] },
+            { name: 'Terrible task', state: 'cannotStartYet', pages: ['pageSix'] },
           ],
         },
       ];
@@ -66,17 +66,17 @@ describe('components', () => {
         {
           name: 'These are your tasks',
           tasks: [
-            { name: 'Nice task', state: 'complete', firstPage: 'pageOne' },
-            { name: 'Ok task', state: 'complete', firstPage: 'pageTwo' },
-            { name: 'Terrible task', state: 'complete', firstPage: 'pageThree' },
+            { name: 'Nice task', state: 'complete', pages: ['pageOne'] },
+            { name: 'Ok task', state: 'complete', pages: ['pageTwo'] },
+            { name: 'Terrible task', state: 'complete', pages: ['pageThree'] },
           ],
         },
         {
           name: 'These are your extra bonus tasks',
           tasks: [
-            { name: 'Nice task', state: 'complete', firstPage: 'pageFour' },
-            { name: 'Ok task', state: 'complete', firstPage: 'pageFive' },
-            { name: 'Terrible task', state: 'complete', firstPage: 'pageSix' },
+            { name: 'Nice task', state: 'complete', pages: ['pageFour'] },
+            { name: 'Ok task', state: 'complete', pages: ['pageFive'] },
+            { name: 'Terrible task', state: 'complete', pages: ['pageSix'] },
           ],
         },
       ];
@@ -99,9 +99,9 @@ describe('components', () => {
         {
           name: 'These are your tasks',
           tasks: [
-            { name: 'Nice task', state: 'complete', firstPage: 'pageOne' },
-            { name: 'Ok task', state: 'complete', firstPage: 'pageTwo' },
-            { name: 'Terrible task', state: 'notStarted', firstPage: 'pageThree' },
+            { name: 'Nice task', state: 'complete', pages: ['pageOne'] },
+            { name: 'Ok task', state: 'complete', pages: ['pageTwo'] },
+            { name: 'Terrible task', state: 'notStarted', pages: ['pageThree'] },
           ],
         },
       ];
@@ -112,7 +112,7 @@ describe('components', () => {
     });
   });
 
-  it('should pass the first page of the selected task to the given onTaskAction function', () => {
+  it('should pass the the selected task to the given onTaskAction function', () => {
     const COP_REF = '123';
     const REF_TITLE = 'COP reference number';
     const ON_CLICK_CALLS = [];
@@ -123,9 +123,9 @@ describe('components', () => {
       {
         name: 'These are your tasks',
         tasks: [
-          { name: 'Nice task', state: 'complete', firstPage: 'pageOne' },
-          { name: 'Ok task', state: 'complete', firstPage: 'pageTwo' },
-          { name: 'Terrible task', state: 'notStarted', firstPage: 'pageThree' },
+          { name: 'Nice task', state: 'complete', pages: ['pageOne'] },
+          { name: 'Ok task', state: 'complete', pages: ['pageTwo'] },
+          { name: 'Terrible task', state: 'notStarted', pages: ['pageThree'] },
         ],
       },
     ];
@@ -136,13 +136,13 @@ describe('components', () => {
     const thirdTask = container.childNodes[0].childNodes[4].childNodes[2].childNodes[0].childNodes[0];
 
     fireEvent.click(firstTask.childNodes[0]);
-    expect(ON_CLICK_CALLS[0]).toEqual('pageOne');
+    expect(ON_CLICK_CALLS[0]).toEqual({ pages: ['pageOne'], name: "Nice task", state: 'complete'});
 
     fireEvent.click(secondTask.childNodes[0]);
-    expect(ON_CLICK_CALLS[1]).toEqual('pageTwo');
+    expect(ON_CLICK_CALLS[1]).toEqual({pages: ['pageTwo'], name: "Ok task", state: 'complete'});
 
     fireEvent.click(thirdTask.childNodes[0]);
-    expect(ON_CLICK_CALLS[2]).toEqual('pageThree');
+    expect(ON_CLICK_CALLS[2]).toEqual({pages: ['pageThree'], name: "Terrible task", state: 'notStarted'});
 
   });
 });

--- a/src/docs/Form.stories.mdx
+++ b/src/docs/Form.stories.mdx
@@ -71,8 +71,8 @@ The sections to group tasks in. Consists of a title and an array of tasks to dis
     * ###### `hub.sections.tasks.name : string`
     The display name for the task.
 
-    * ###### `hub.sections.tasks.firstPage : string`
-    The first page to launch for the task.
+    * ###### `hub.sections.tasks.pages : [ string ]`
+    The pages to include in this task. The first in the array will be taken as the start point. 
 
     * ###### `hub.sections.tasks.state : string`
     The current state of the task.

--- a/src/json/taskList.json
+++ b/src/json/taskList.json
@@ -1,0 +1,228 @@
+{
+  "id": "eventAtTheBorder",
+  "version": "1",
+  "name": "Event at the border",
+  "title": "Event at the border",
+  "type": "task-list",
+  "components": [
+    {
+      "id": "firstName",
+      "fieldId": "firstName",
+      "label": "First name",
+      "type": "text",
+      "required": true
+    },
+    {
+      "id": "surname",
+      "fieldId": "surname",
+      "label": "Last name",
+      "type": "text",
+      "required": true
+    },
+    {
+      "id": "date",
+      "fieldId": "date",
+      "label": "Date",
+      "type": "date",
+      "required": true
+    },
+    {
+      "id": "officerName",
+      "fieldId": "officerName",
+      "label": "Officer Name",
+      "type": "text"
+    },
+    {
+      "id": "immigrationDate",
+      "fieldId": "immigrationDate",
+      "label": "Immigration Date",
+      "type": "date",
+      "required": true
+    },
+    {
+      "id": "mode",
+      "fieldId": "mode",
+      "label": "Mode",
+      "type": "radios",
+      "data": {
+        "options": [
+          {
+            "value": "sea",
+            "label": "Sea"
+          },
+          {
+            "value": "air",
+            "label": "Air"
+          }
+        ]
+      },
+      "required": true
+    }
+  ],
+  "pages": [
+    {
+      "id": "eventDate",
+      "name": "eventDate",
+      "title": "Event Date",
+      "components": [
+        {
+          "use": "date"
+        }
+      ],
+      "actions": [
+        {
+          "type": "saveAndNavigate",
+          "page": "eventMode"
+        }
+      ],
+      "cya_link": {
+        "page": "eventDate",
+        "aria_suffix": "Event Date"
+      }
+    },
+    {
+      "id": "eventMode",
+      "name": "eventMode",
+      "title": "Event Mode",
+      "components": [
+        {
+          "use": "mode"
+        }
+      ],
+      "actions": [
+        {
+          "type": "saveAndNavigate",
+          "page": "cya"
+        }
+      ],
+      "cya_link": {
+        "page": "eventMode",
+        "aria_suffix": "Event Mode"
+      }
+    },
+    {
+      "id": "officeDetails",
+      "name": "officeDetails",
+      "title": "Officer Details",
+      "components": [
+        {
+          "use": "officerName"
+        }
+      ],
+      "actions": [
+        {
+          "type": "saveAndNavigate",
+          "page": "cya"
+        }
+      ],
+      "cya_link": {
+        "page": "officeDetails",
+        "aria_suffix": "Officer Details"
+      }
+    },
+    {
+      "id": "immigrationDate",
+      "name": "immigrationDate",
+      "title": "Immigration Date",
+      "components": [
+        {
+          "use": "immigrationDate"
+        }
+      ],
+      "actions": [
+        {
+          "type": "saveAndNavigate",
+          "page": "cya"
+        }
+      ],
+      "cya_link": {
+        "page": "immigrationDate",
+        "aria_suffix": "Immigration Date"
+      }
+    },
+    {
+      "id": "firstName",
+      "name": "firstName",
+      "title": "First Name",
+      "components": [
+        {
+          "use": "firstName"
+        }
+      ],
+      "actions": [
+        {
+          "type": "saveAndNavigate",
+          "page": "surname"
+        }
+      ],
+      "cya_link": {
+        "page": "firstName",
+        "aria_suffix": "First Name"
+      }
+    },
+    {
+      "id": "surname",
+      "name": "surname",
+      "title": "Surname",
+      "components": [
+        {
+          "use": "surname"
+        }
+      ],
+      "actions": [
+        {
+          "type": "saveAndNavigate",
+          "page": "cya"
+        }
+      ],
+      "cya_link": {
+        "page": "surname",
+        "aria_suffix": "Surname"
+      }
+    }
+  ],
+  "hub": {
+    "format": "CYA",
+    "refTitle": "COP reference number",
+    "sections": [
+      {
+        "name": "Add event details",
+        "tasks": [
+          {
+            "name": "Date, location and mode details",
+            "pages": ["eventDate", "eventMode"],
+            "state": "complete"
+          },
+          {
+            "name": "Officer and agency details",
+            "pages": ["officeDetails"],
+            "state": "inProgress"
+          }
+        ]
+      },
+      {
+        "name": "Add people details",
+        "tasks": [
+          {
+            "name": "People details",
+            "pages": ["firstName", "surname"],
+            "state": "complete"
+          },
+          {
+            "name": "Immigration details",
+            "pages": ["immigrationDate"],
+            "state": "inProgress"
+          },
+          {
+            "name": "Journey details",
+            "pages": ["none"],
+            "state": "cannotStartYet"
+          }
+        ]
+      }
+    ]
+  },
+  "cya": {
+    "hide_page_titles": false
+  }
+}

--- a/src/models/PageAction.js
+++ b/src/models/PageAction.js
@@ -1,11 +1,13 @@
 const TYPE_NAVIGATE = 'navigate';
 const TYPE_SAVE_AND_CONTINUE = 'saveAndContinue';
+const TYPE_SAVE_AND_NAVIGATE = 'saveAndNavigate';
 const TYPE_SAVE_AND_RETURN = 'saveAndReturn';
 const TYPE_SUBMIT = 'submit';
 
 export const PageActionTypes = {
   NAVIGATE: TYPE_NAVIGATE,
   SAVE_AND_CONTINUE: TYPE_SAVE_AND_CONTINUE,
+  SAVE_AND_NAVIGATE: TYPE_SAVE_AND_NAVIGATE,
   SAVE_AND_RETURN: TYPE_SAVE_AND_RETURN,
   SUBMIT: TYPE_SUBMIT
 };
@@ -13,6 +15,7 @@ export const PageActionTypes = {
 export const DefaultPageActions = {
   [TYPE_NAVIGATE]: undefined, // No default for this.
   [TYPE_SAVE_AND_CONTINUE]: { type: TYPE_SAVE_AND_CONTINUE, validate: true, label: 'Save and continue' },
+  [TYPE_SAVE_AND_NAVIGATE]: { type: TYPE_SAVE_AND_NAVIGATE, validate: true },
   [TYPE_SAVE_AND_RETURN]: { type: TYPE_SAVE_AND_RETURN, validate: false, label: 'Save and return later', classModifiers: 'secondary' },
   [TYPE_SUBMIT]: { type: TYPE_SUBMIT, validate: true }
 };

--- a/src/utils/FormPage/getPageActions.js
+++ b/src/utils/FormPage/getPageActions.js
@@ -31,6 +31,9 @@ const getPageActions = (page) => {
         return PageAction.DEFAULTS[a];
       }
       if (a && typeof a === 'object') {
+        if(PageAction.DEFAULTS[a.type]?.validate){
+          a.validate = true;
+        }
         return standardiseAction(a);
       }
       return undefined;


### PR DESCRIPTION
Add the functionality to move from the tasklist hub to individual sections, through each page in the section and finally end on a CYA page for the section. Adds a new action type to allow returning from a CYA screen to the tasklist rather than submitting the form. 

The inter-section navigation is reliant on the JSON for each page specifying which page should come next. This seemed like the simplest method and allows versatility in the form of optionally adding CYA as the final page. However this does lead to some duplication as each section specifies the pages it includes as well which is required to populate the CYA pages with the correct fields.