### PR TITLE
COP-9885 Add task state management

### DIFF
--- a/src/components/FormRenderer/helpers/getSubmissionStatus.js
+++ b/src/components/FormRenderer/helpers/getSubmissionStatus.js
@@ -1,7 +1,23 @@
-import { PageAction } from '../../../models';
+import { FormPages, FormTypes, PageAction } from '../../../models';
 import getNextPageId from './getNextPageId';
 
-const getSubmissionStatus = (formType, pages, currentPageId, action, formData) => {
+const getSubmissionStatus = (formType, pages, currentPageId, action, formData, currentTask) => {
+  if (formType === FormTypes.TASK) {
+    const formStatus = formData.formStatus ? formData.formStatus : {};
+    formStatus.tasks = formStatus.tasks ? formStatus.tasks : {};
+    formStatus.tasks[currentTask.name] = formStatus.tasks[currentTask.name] ? formStatus.tasks[currentTask.name] : {};
+
+    if (currentPageId === FormPages.CYA) {
+      formStatus.tasks[currentTask.name].complete = true;
+    } else {
+      formStatus.tasks[currentTask.name] = {
+        complete: false,
+        currentPage: action.page
+      };
+    }
+    return formStatus;
+  }
+
   if (action?.type === PageAction.TYPES.SAVE_AND_RETURN) {
     return { page: currentPageId };
   }

--- a/src/components/FormRenderer/helpers/getSubmissionStatus.test.js
+++ b/src/components/FormRenderer/helpers/getSubmissionStatus.test.js
@@ -1,5 +1,6 @@
 // Local imports
 import { ComponentTypes, FormPages, FormTypes, PageAction } from '../../../models';
+import { PageActionTypes } from '../../../models/PageAction';
 import getSubmissionStatus from './getSubmissionStatus';
 
 describe('components', () => {
@@ -55,12 +56,14 @@ describe('components', () => {
         describe(`when the action type is '${PageAction.TYPES.SAVE_AND_RETURN}'`, () => {
 
           Object.values(FormTypes).forEach(formType => {
-            it(`should return the current page if the form type is '${formType}'`, () => {
-              const ACTION = PageAction.DEFAULTS.saveAndReturn;
-              expect(getSubmissionStatus(formType, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toMatchObject({
-                page: PAGES[0].id
+            if(formType !== FormTypes.TASK){
+              it(`should return the current page if the form type is '${formType}'`, () => {
+                const ACTION = PageAction.DEFAULTS.saveAndReturn;
+                expect(getSubmissionStatus(formType, PAGES, PAGES[0].id, ACTION, FORM_DATA)).toMatchObject({
+                  page: PAGES[0].id
+                });
               });
-            });
+            }
           });
 
         });
@@ -166,7 +169,35 @@ describe('components', () => {
 
         });
 
+      describe(`when the form type is '${FormTypes.TASK}'`, () => {
+        const FORM_TYPE = FormTypes.TASK;
+
+        it(`should mark the current task as complete if the current page is '${FormPages.CYA}'`, () => {
+          const CURRENT_PAGE_ID = FormPages.CYA;
+          const TASK_NAME = 'taskName';
+          const CURRENT_TASK = { name: TASK_NAME };
+          expect(getSubmissionStatus(FORM_TYPE, PAGES, CURRENT_PAGE_ID, undefined, {}, CURRENT_TASK)).toMatchObject({
+            tasks: { [TASK_NAME]: { complete: true } },
+          });
+        });
+
+        it(`should update the current task with the next page and a false complete flag if the current page is not '${FormPages.CYA}'`, () => {
+          const CURRENT_PAGE_ID = 'eventDate';
+          const TASK_NAME = 'taskName';
+          const CURRENT_TASK = { name: TASK_NAME };
+          const NEXT_PAGE_ID = 'eventMode';
+          const ACTION = {
+            type:PageActionTypes.SAVE_AND_NAVIGATE,
+            page: NEXT_PAGE_ID,
+          };
+          expect(getSubmissionStatus(FORM_TYPE, PAGES, CURRENT_PAGE_ID, ACTION, {}, CURRENT_TASK)).toMatchObject({
+            tasks: { [TASK_NAME]: { complete: false, currentPage: NEXT_PAGE_ID } },
+          });
+        });
+
       });
+
+    });
 
     });
 

--- a/src/components/FormRenderer/helpers/getUpdatedSectionStates.js
+++ b/src/components/FormRenderer/helpers/getUpdatedSectionStates.js
@@ -1,0 +1,40 @@
+import { TaskStates } from '../../../models';
+
+/**
+ * Updates the given task list sections with the latest states
+ * @param {object} sections The JSON defining the sections in the task list
+ * @param {object} tasks object with entry for each task containing currentPage and complete boolean flag 
+ * {
+     "TaskName": {
+       "complete": true,
+       "currentPage": "pageId"
+     }
+   }
+ * @returns An JSON representation of the task list sections with up to date states
+ */
+const getUpdatedSectionStates = (sections, tasks) => {
+  return sections.map((section, sectionIndex, sectionArray) => {
+    return section.tasks.map((task, taskIndex, taskArray) => {
+      if (tasks[task.name]) {
+        if (tasks[task.name].complete) {
+          task.state = TaskStates.TYPES.COMPLETE;
+        } else if (tasks[task.name].currentPage) {
+          task.state = TaskStates.TYPES.IN_PROGRESS;
+        }
+      } else {
+        if (
+          (taskIndex === 0 && sectionIndex === 0) || //First task in tasklist
+          taskArray[taskIndex - 1]?.state === TaskStates.TYPES.COMPLETE || //any task after a complete task in same section
+          (taskIndex === 0 && sectionArray[sectionIndex - 1]?.tasks.slice(-1)[0]?.state === TaskStates.TYPES.COMPLETE) //any task after a complete task in the preceeding section
+        ) {
+          task.state = TaskStates.TYPES.NOT_STARTED;
+        } else {
+          task.state = TaskStates.TYPES.CANNOT_START_YET;
+        }
+      }
+      return task;
+    });
+  });
+};
+
+export default getUpdatedSectionStates;

--- a/src/components/FormRenderer/helpers/getUpdatedSectionStates.test.js
+++ b/src/components/FormRenderer/helpers/getUpdatedSectionStates.test.js
@@ -1,0 +1,133 @@
+// Local imports
+import getUpdatedSectionStates from './getUpdatedSectionStates';
+import { TaskStates } from '../../../models';
+
+describe('components', () => {
+  describe('FormRenderer', () => {
+    describe('helpers', () => {
+      describe('getUpdatedSectionStates', () => {
+        it(`should set all tasks to '${TaskStates.TYPES.CANNOT_START_YET}' excluding the first which should be '${TaskStates.TYPES.NOT_STARTED}'`, () => {
+          const SECTIONS = [
+            {
+              name: 'Add event details',
+              tasks: [
+                {
+                  name: 'Date, location and mode details',
+                  pages: ['eventDate', 'eventMode'],
+                },
+                {
+                  name: 'Officer and agency details',
+                  pages: ['officeDetails'],
+                },
+              ],
+            },
+            {
+              name: 'Add people details',
+              tasks: [
+                {
+                  name: 'People details',
+                  pages: ['firstName', 'surname'],
+                },
+                {
+                  name: 'Immigration details',
+                  pages: ['immigrationDate'],
+                },
+                {
+                  name: 'Journey details',
+                  pages: ['journeyDetails'],
+                },
+              ],
+            },
+          ];
+          const updatedSections = getUpdatedSectionStates(SECTIONS, {});
+          expect(updatedSections[0][0].state).toEqual(TaskStates.TYPES.NOT_STARTED);
+          expect(updatedSections[0][1].state).toEqual(TaskStates.TYPES.CANNOT_START_YET);
+          expect(updatedSections[1][0].state).toEqual(TaskStates.TYPES.CANNOT_START_YET);
+          expect(updatedSections[1][1].state).toEqual(TaskStates.TYPES.CANNOT_START_YET);
+          expect(updatedSections[1][2].state).toEqual(TaskStates.TYPES.CANNOT_START_YET);
+        });
+
+        it(`should set tasks after any '${TaskStates.TYPES.COMPLETE}' ones to '${TaskStates.TYPES.NOT_STARTED}'`, () => {
+          const SECTIONS = [
+            {
+              name: 'Add event details',
+              tasks: [
+                {
+                  name: 'Date, location and mode details',
+                  pages: ['eventDate', 'eventMode'],
+                },
+                {
+                  name: 'Officer and agency details',
+                  pages: ['officeDetails'],
+                },
+              ],
+            },
+          ];
+          const TASKS = { 'Date, location and mode details': { complete: true } };
+          const updatedSections = getUpdatedSectionStates(SECTIONS, TASKS);
+          expect(updatedSections[0][0].state).toEqual(TaskStates.TYPES.COMPLETE);
+          expect(updatedSections[0][1].state).toEqual(TaskStates.TYPES.NOT_STARTED);
+        });
+
+        it(`should set tasks after any '${TaskStates.TYPES.COMPLETE}' ones to '${TaskStates.TYPES.NOT_STARTED} across different sections'`, () => {
+          const SECTIONS = [
+            {
+              name: 'Add event details',
+              tasks: [
+                {
+                  name: 'Date, location and mode details',
+                  pages: ['eventDate', 'eventMode'],
+                },
+                {
+                  name: 'Officer and agency details',
+                  pages: ['officeDetails'],
+                },
+              ],
+            },
+            {
+              name: 'Add people details',
+              tasks: [
+                {
+                  name: 'People details',
+                  pages: ['firstName', 'surname'],
+                },
+                {
+                  name: 'Immigration details',
+                  pages: ['immigrationDate'],
+                },
+              ],
+            },
+          ];
+          const TASKS = { 'Date, location and mode details': { complete: true }, 'Officer and agency details': { complete: true } };
+          const updatedSections = getUpdatedSectionStates(SECTIONS, TASKS);
+          expect(updatedSections[0][0].state).toEqual(TaskStates.TYPES.COMPLETE);
+          expect(updatedSections[0][1].state).toEqual(TaskStates.TYPES.COMPLETE);
+          expect(updatedSections[1][0].state).toEqual(TaskStates.TYPES.NOT_STARTED);
+          expect(updatedSections[1][1].state).toEqual(TaskStates.TYPES.CANNOT_START_YET);
+        });
+
+        it(`should set tasks to '${TaskStates.TYPES.IN_PROGRESS}' if they have a current page but are not complete`, () => {
+          const SECTIONS = [
+            {
+              name: 'Add event details',
+              tasks: [
+                {
+                  name: 'Date, location and mode details',
+                  pages: ['eventDate', 'eventMode'],
+                },
+                {
+                  name: 'Officer and agency details',
+                  pages: ['officeDetails'],
+                },
+              ],
+            },
+          ];
+          const TASKS = { 'Date, location and mode details': { complete: false, currentPage: 'eventMode' } };
+          const updatedSections = getUpdatedSectionStates(SECTIONS, TASKS);
+          expect(updatedSections[0][0].state).toEqual(TaskStates.TYPES.IN_PROGRESS);
+          expect(updatedSections[0][1].state).toEqual(TaskStates.TYPES.CANNOT_START_YET);
+        });
+      });
+    });
+  });
+});

--- a/src/components/FormRenderer/helpers/index.js
+++ b/src/components/FormRenderer/helpers/index.js
@@ -3,13 +3,17 @@ import canActionProceed from './canActionProceed';
 import canCYASubmit from './canCYASubmit';
 import getFormState from './getFormState';
 import getNextPageId from './getNextPageId';
+import getPage from './getPage';
 import getSubmissionStatus from './getSubmissionStatus';
+import getUpdatedSectionStates from './getUpdatedSectionStates';
 
 export const helpers = {
   canActionProceed,
   canCYASubmit,
   getFormState,
   getNextPageId,
-  getSubmissionStatus
+  getPage,
+  getSubmissionStatus,
+  getUpdatedSectionStates
 };
 export default helpers;

--- a/src/components/TaskList/Task.jsx
+++ b/src/components/TaskList/Task.jsx
@@ -18,7 +18,7 @@ const Task = ({ task, onClick }) => {
   useEffect(() => {
     setLinkActive(task.state !== TaskStates.TYPES.CANNOT_START_YET);
     setCurrentState(task.state);
-  }, [task, setLinkActive, setCurrentState]);
+  }, [task.state, setLinkActive, setCurrentState]);
 
   return (
     <li className={classes('item')}>


### PR DESCRIPTION
### Description
Add management of the state of each task. The task state can be 'Cannot Start', 'Not Started, 'In Progress' or 'Complete'. This information is stored in the backend and updated as the user progresses through the task list. Details for when tasks should be in each state and progress to the next one are covered in the jira ticket. 

The updates to `FormRenderer.jsx` largely cover the updating of states when the user either moves to the next page or completes a section. This uses the new helper function `getUpdatedSectionStates()` to determine each tasks state and an updated `getSubmissionStatus()` to add state information to the submitted data object.

### Testing
Covered by unit tests