### PR TITLE
COP-10558: Support containers on Check your answers screen

### DIFF
--- a/src/utils/CheckYourAnswers/getCYARowsForContainer.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForContainer.js
@@ -1,0 +1,18 @@
+// Local imports
+import { ComponentTypes } from '../../models';
+import getCYARow from './getCYARow';
+import showComponentCYA from './showComponentCYA';
+
+const getCYARowsForContainer = (page, container, formData, onAction) => {
+  if (showComponentCYA(container, page.formData)) {
+    return container.components.filter(c => showComponentCYA(c, page.formData)).flatMap(component => {
+      if (component.type === ComponentTypes.CONTAINER) {
+        const fd = formData ? formData[component.fieldId] : undefined;
+        return getCYARowsForContainer(page, component, fd, onAction);
+      }
+      return getCYARow({ ...page, formData }, component, onAction);
+    });
+  }
+};
+
+export default getCYARowsForContainer;

--- a/src/utils/CheckYourAnswers/getCYARowsForContainer.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForContainer.test.js
@@ -1,0 +1,183 @@
+// Local imports
+import { ComponentTypes } from '../../models';
+import getCYARowsForContainer from './getCYARowsForContainer';
+
+describe('utils.CheckYourAnswers.getCYARowsForContainer', () => {
+
+  const expectObjectLike = (received, expected) => {
+    Object.keys(expected).forEach(key => {
+      expect(received[key]).toEqual(expected[key]);
+    });
+  };
+
+  it('should get an appropriate row for a container with a single readonly text component', () => {
+    const FORM_DATA = {
+      container: {
+        a: 'Bravo'
+      }
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+    const CONTAINER = {
+      id: 'container',
+      fieldId: 'container',
+      type: ComponentTypes.CONTAINER,
+      components: [ COMPONENT ],
+      value: FORM_DATA.container,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForContainer(PAGE, CONTAINER, FORM_DATA.container, ON_ACTION);
+    expect(ROWS.length).toEqual(1);
+    ROWS.forEach((row, index) => {
+      expectObjectLike(row, {
+        pageId: PAGE.id,
+        fieldId: CONTAINER.components[index].fieldId,
+        key: CONTAINER.components[index].label,
+        action: null,
+        component: COMPONENT,
+        value: 'Bravo'
+      });
+    });
+  });
+
+  it('should get appropriate rows for a container with two editable text components', () => {
+    const FORM_DATA = {
+      container: {
+        a: 'Alpha Charlie',
+        b: 'Bravo Charlie'
+      }
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT_A = { type: 'text', id: 'a', fieldId: 'a', label: 'Alpha' };
+    const COMPONENT_B = { type: 'text', id: 'b', fieldId: 'b', label: 'Bravo' };
+    const CONTAINER = {
+      id: 'container',
+      fieldId: 'container',
+      type: ComponentTypes.CONTAINER,
+      components: [ COMPONENT_A, COMPONENT_B ],
+      value: FORM_DATA.container,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForContainer(PAGE, CONTAINER, FORM_DATA.container, ON_ACTION);
+    expect(ROWS.length).toEqual(2);
+    ROWS.forEach((row, index) => {
+      expectObjectLike(row, {
+        pageId: PAGE.id,
+        fieldId: CONTAINER.components[index].fieldId,
+        key: CONTAINER.components[index].label,
+        component: CONTAINER.components[index],
+        value: `${CONTAINER.components[index].label} Charlie`
+      });
+      expectObjectLike(row.action, { onAction: ON_ACTION });
+    });
+  });
+
+  it(`should filter out any components that shouldn't be shown`, () => {
+    const FORM_DATA = {
+      container: {
+        a: 'Alpha Charlie',
+        b: 'Bravo Charlie'
+      }
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT_A = { type: 'text', id: 'a', fieldId: 'a', label: 'Alpha' };
+    const COMPONENT_B = { type: 'text', id: 'b', fieldId: 'b', label: 'Bravo' };
+    const COMPONENT_C = { type: 'heading', content: 'Heading component' };
+    const CONTAINER = {
+      id: 'container',
+      fieldId: 'container',
+      type: ComponentTypes.CONTAINER,
+      components: [ COMPONENT_A, COMPONENT_B, COMPONENT_C ],
+      value: FORM_DATA.container,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForContainer(PAGE, CONTAINER, FORM_DATA.container, ON_ACTION);
+    expect(ROWS.length).toEqual(2);
+    ROWS.forEach((row, index) => {
+      expectObjectLike(row, {
+        pageId: PAGE.id,
+        fieldId: CONTAINER.components[index].fieldId,
+        key: CONTAINER.components[index].label,
+        component: CONTAINER.components[index],
+        value: `${CONTAINER.components[index].label} Charlie`
+      });
+      expectObjectLike(row.action, { onAction: ON_ACTION });
+    });
+  });
+
+  it('should get an appropriate row for a container with a single readonly text component inside a nested container', () => {
+    const FORM_DATA = {
+      container: {
+        nested: {
+          a: 'Bravo'
+        }
+      }
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+    const NESTED_CONTAINER = {
+      id: 'nested',
+      fieldId: 'nested',
+      type: ComponentTypes.CONTAINER,
+      components: [ COMPONENT ],
+      value: FORM_DATA.container.nested,
+      formData: FORM_DATA
+    };
+    const CONTAINER = {
+      id: 'container',
+      fieldId: 'container',
+      type: ComponentTypes.CONTAINER,
+      components: [ NESTED_CONTAINER ],
+      value: FORM_DATA.container,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForContainer(PAGE, CONTAINER, FORM_DATA.container, ON_ACTION);
+    expect(ROWS.length).toEqual(1);
+    ROWS.forEach((row, index) => {
+      expectObjectLike(row, {
+        pageId: PAGE.id,
+        fieldId: NESTED_CONTAINER.components[index].fieldId,
+        key: NESTED_CONTAINER.components[index].label,
+        action: null,
+        component: COMPONENT,
+        value: 'Bravo'
+      });
+    });
+  });
+
+  it('should get an appropriate row for a container with a single readonly text component inside a nested container but no formData', () => {
+    const FORM_DATA = undefined;
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+    const NESTED_CONTAINER = {
+      id: 'nested',
+      fieldId: 'nested',
+      type: ComponentTypes.CONTAINER,
+      components: [ COMPONENT ]
+    };
+    const CONTAINER = {
+      id: 'container',
+      fieldId: 'container',
+      type: ComponentTypes.CONTAINER,
+      components: [ NESTED_CONTAINER ]
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForContainer(PAGE, CONTAINER, undefined, ON_ACTION);
+    expect(ROWS.length).toEqual(1);
+    ROWS.forEach((row, index) => {
+      expectObjectLike(row, {
+        pageId: PAGE.id,
+        fieldId: NESTED_CONTAINER.components[index].fieldId,
+        key: NESTED_CONTAINER.components[index].label,
+        action: null,
+        component: COMPONENT,
+        value: ''
+      });
+    });
+  });
+  
+});

--- a/src/utils/CheckYourAnswers/getCYARowsForPage.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForPage.js
@@ -1,6 +1,8 @@
 // Local imports
+import { ComponentTypes } from '../../models';
 import FormPage from '../FormPage';
 import getCYARow from './getCYARow';
+import getCYARowsForContainer from './getCYARowsForContainer';
 import showComponentCYA from './showComponentCYA';
 
 /**
@@ -13,7 +15,10 @@ import showComponentCYA from './showComponentCYA';
  */
 const getCYARowsForPage = (page, onAction) => {
   if (FormPage.show(page, page.formData)) {
-    return page.components.filter(c => showComponentCYA(c, page.formData)).map(component => {
+    return page.components.filter(c => showComponentCYA(c, page.formData)).flatMap(component => {
+      if (component.type === ComponentTypes.CONTAINER) {
+        return getCYARowsForContainer(page, component, page.formData[component.fieldId], onAction);
+      }
       return getCYARow(page, component, onAction);
     });
   }

--- a/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
@@ -1,4 +1,5 @@
 // Local imports
+import { ComponentTypes } from '../../models';
 import getCYARowsForPage from './getCYARowsForPage';
 
 describe('utils', () => {
@@ -81,6 +82,41 @@ describe('utils', () => {
             value: `${PAGE.components[index].label} Charlie`
           });
           expectObjectLike(row.action, { onAction: ON_ACTION });
+        });
+      });
+
+      it('should get a appropriate row for a page with a single readonly text component inside of a container', () => {
+        const FORM_DATA = {
+          container: {
+            a: 'Bravo'
+          }
+        };
+        const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+        const CONTAINER = {
+          id: 'container',
+          fieldId: 'container',
+          type: ComponentTypes.CONTAINER,
+          components: [ COMPONENT ],
+          value: FORM_DATA.container,
+          formData: FORM_DATA
+        };
+        const PAGE = {
+          id: 'page',
+          components: [ CONTAINER ],
+          formData: FORM_DATA
+        };
+        const ON_ACTION = () => {};
+        const ROWS = getCYARowsForPage(PAGE, ON_ACTION);
+        expect(ROWS.length).toEqual(1);
+        ROWS.forEach((row, index) => {
+          expectObjectLike(row, {
+            pageId: PAGE.id,
+            fieldId: CONTAINER.components[index].fieldId,
+            key: CONTAINER.components[index].label,
+            action: null,
+            component: COMPONENT,
+            value: 'Bravo'
+          });
         });
       });
       

--- a/src/utils/CheckYourAnswers/showComponentCYA.js
+++ b/src/utils/CheckYourAnswers/showComponentCYA.js
@@ -1,6 +1,7 @@
 // Local imports
 import { ComponentTypes } from '../../models';
 import Component from '../Component';
+import Container from '../Container';
 
 const EXCLUDE_FROM_CYA = [
   ComponentTypes.HEADING,
@@ -22,6 +23,9 @@ const showComponentCYA = (options, data) => {
   }
   if (EXCLUDE_FROM_CYA.includes(options.type)) {
     return false;
+  }
+  if (options.type === ComponentTypes.CONTAINER) {
+    return Container.show(options, data);
   }
   return Component.show(options, data);
 };


### PR DESCRIPTION
### Description
Support `Container` components on the **Check your answers** screen. Presently, each editable component within a `Container` will be handled exactly the same as if it was at the top level of the form.

https://support.cop.homeoffice.gov.uk/browse/COP-10558

### To test
Covered by accompanying unit tests.