### PR TITLE
Feature/c op 2120 cya validation

### DIFF
--- a/src/components/FormRenderer/helpers/canActionProceed.js
+++ b/src/components/FormRenderer/helpers/canActionProceed.js
@@ -12,7 +12,7 @@ import Utils from '../../../utils';
  */
 const canActionProceed = (action, page, onError) => {
   if (action.validate) {
-    const errors = Utils.Validate.page(page.components, page.formData);
+    const errors = Utils.Validate.page(page.components, page.formData, page);
     onError(errors);
     return errors.length === 0;
   }

--- a/src/components/FormRenderer/helpers/canActionProceed.js
+++ b/src/components/FormRenderer/helpers/canActionProceed.js
@@ -12,7 +12,7 @@ import Utils from '../../../utils';
  */
 const canActionProceed = (action, page, onError) => {
   if (action.validate) {
-    const errors = Utils.Validate.page(page.components, page.formData, page);
+    const errors = Utils.Validate.page(page);
     onError(errors);
     return errors.length === 0;
   }

--- a/src/components/FormRenderer/helpers/canCYASubmit.js
+++ b/src/components/FormRenderer/helpers/canCYASubmit.js
@@ -12,7 +12,7 @@ import Utils from '../../../utils';
 const canCYASubmit = (pages, onError) => {
   const errors = [];
   pages.forEach(p => {
-    errors.push(...Utils.Validate.page(p.components, p.formData, p));
+    errors.push(...Utils.Validate.page(p));
   });
   onError(errors);
   return errors.length === 0;

--- a/src/components/FormRenderer/helpers/canCYASubmit.js
+++ b/src/components/FormRenderer/helpers/canCYASubmit.js
@@ -12,7 +12,7 @@ import Utils from '../../../utils';
 const canCYASubmit = (pages, onError) => {
   const errors = [];
   pages.forEach(p => {
-    errors.push(...Utils.Validate.page(p.components, p.formData));
+    errors.push(...Utils.Validate.page(p.components, p.formData, p));
   });
   onError(errors);
   return errors.length === 0;

--- a/src/utils/Validate/validatePage.js
+++ b/src/utils/Validate/validatePage.js
@@ -10,12 +10,13 @@ import showFormPage from '../FormPage/showFormPage';
  * @returns An array containing all of the errors.
  */
  const validatePage = (page) => {
-  if (Array.isArray(page.components) && showFormPage(page, page.formData)) {
+  if (Array.isArray(page?.components) && showFormPage(page, page.formData)) {
     return page.components.reduce((errors, component) => {
       return errors.concat(validateComponent(component, page.formData));
     }, []).filter(e => !!e).flat();
   }
   return [];
 };
+
 
 export default validatePage;

--- a/src/utils/Validate/validatePage.js
+++ b/src/utils/Validate/validatePage.js
@@ -1,5 +1,6 @@
 // Local imports
 import validateComponent from './validateComponent';
+import showFormPage from '../FormPage/showFormPage';
 
 /**
  * Validate all of the components on a page.
@@ -7,8 +8,8 @@ import validateComponent from './validateComponent';
  * @param {object} formData The data to use that holds this components' values.
  * @returns An array containing all of the errors.
  */
-const validatePage = (components, formData) => {
-  if (Array.isArray(components)) {
+const validatePage = (components, formData, page) => {
+  if (Array.isArray(components) && showFormPage(page, formData)) {
     return components.reduce((errors, component) => {
       return errors.concat(validateComponent(component, formData));
     }, []).filter(e => !!e).flat();

--- a/src/utils/Validate/validatePage.js
+++ b/src/utils/Validate/validatePage.js
@@ -4,19 +4,16 @@ import showFormPage from '../FormPage/showFormPage';
 
 /**
  * Validate all of the components on a page.
- * @param {object} page The page to validate, contains:
- * @param {Array} components The components to validate.
- * @param {object} formData The data to use that holds this components' values.
+ * @param {object} page The page to validate
  * @returns An array containing all of the errors.
  */
- const validatePage = (page) => {
-  if (Array.isArray(page?.components) && showFormPage(page, page.formData)) {
+const validatePage = (page) => {
+  if (showFormPage(page, page.formData) && Array.isArray(page.components)) {
     return page.components.reduce((errors, component) => {
       return errors.concat(validateComponent(component, page.formData));
     }, []).filter(e => !!e).flat();
   }
   return [];
 };
-
 
 export default validatePage;

--- a/src/utils/Validate/validatePage.js
+++ b/src/utils/Validate/validatePage.js
@@ -4,14 +4,15 @@ import showFormPage from '../FormPage/showFormPage';
 
 /**
  * Validate all of the components on a page.
+ * @param {object} page The page to validate, contains:
  * @param {Array} components The components to validate.
  * @param {object} formData The data to use that holds this components' values.
  * @returns An array containing all of the errors.
  */
-const validatePage = (components, formData, page) => {
-  if (Array.isArray(components) && showFormPage(page, formData)) {
-    return components.reduce((errors, component) => {
-      return errors.concat(validateComponent(component, formData));
+ const validatePage = (page) => {
+  if (Array.isArray(page.components) && showFormPage(page, page.formData)) {
+    return page.components.reduce((errors, component) => {
+      return errors.concat(validateComponent(component, page.formData));
     }, []).filter(e => !!e).flat();
   }
   return [];

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -13,11 +13,11 @@ describe('utils', () => {
       };
 
       it('should return no error when the components array is null', () => {
-        expect(validatePage(null, {}).length).toEqual(0);
+        expect(validatePage(null).length).toEqual(0);
       });
 
       it('should return no error when the components array is empty', () => {
-        expect(validatePage([], {}).length).toEqual(0);
+        expect(validatePage(null).length).toEqual(0);
       });
 
       describe('when there is no form data', () => {
@@ -27,7 +27,11 @@ describe('utils', () => {
             setup('a', ComponentTypes.TEXT, 'Alpha', false),
             setup('b', ComponentTypes.TEXT, 'Bravo', false)
           ];
-          expect(validatePage(COMPONENTS, null).length).toEqual(0);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: null
+          };
+          expect(validatePage(PAGE).length).toEqual(0);
         });
 
         it('should return an error for each required component', () => {
@@ -63,7 +67,11 @@ describe('utils', () => {
             setup('alpha', ComponentTypes.TEXT, 'Alpha', false),
             setup('bravo', ComponentTypes.TEXT, 'Bravo', false)
           ];
-          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: DATA
+          };
+          expect(validatePage(PAGE).length).toEqual(0);
         });
 
         it('should return no errors when all of the components are required but not email types', () => {

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -15,7 +15,7 @@ describe('utils', () => {
       it('should return no error when the components array is null', () => {
         const PAGE = {
           components: null,
-          formData: {}
+          formData: null
         };
         expect(validatePage(PAGE).length).toEqual(0);
       });

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -104,7 +104,11 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.TEXT, 'Bravo', false),
             setup('charlie', ComponentTypes.TEXT, 'Charlie', false)
           ];
-          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: null
+          };
+          expect(validatePage(PAGE).length).toEqual(0);
         });
 
         it('should return an error for the missing field when all are required but not email types', () => {
@@ -115,7 +119,7 @@ describe('utils', () => {
           ];
           const PAGE = {
             components: COMPONENTS,
-            formData: null
+            formData: DATA
           };
           const RESULT = validatePage(PAGE);
           expect(RESULT.length).toEqual(1);
@@ -131,7 +135,11 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.EMAIL, 'Bravo', false),
             setup('charlie', ComponentTypes.EMAIL, 'Charlie', false)
           ];
-          const RESULT = validatePage(COMPONENTS, DATA, []);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: DATA
+          };
+          const RESULT = validatePage(PAGE);
           expect(RESULT.length).toEqual(1);
           expect(RESULT[0]).toEqual({
             id: 'bravo',
@@ -145,7 +153,11 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.EMAIL, 'Bravo', true),
             setup('charlie', ComponentTypes.EMAIL, 'Charlie', true)
           ];
-          const RESULT = validatePage(COMPONENTS, DATA, []);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: DATA
+          };
+          const RESULT = validatePage(PAGE);
           expect(RESULT.length).toEqual(2);
           expect(RESULT[0]).toEqual({
             id: 'bravo',

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -38,7 +38,11 @@ describe('utils', () => {
             setup('d', ComponentTypes.TEXT, 'Delta', true),
             setup('e', ComponentTypes.TEXT, 'Echo', true)
           ];
-          const RESULT = validatePage(COMPONENTS, null, []);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: null
+          };
+          const RESULT = validatePage(PAGE);
           expect(RESULT.length).toEqual(4);
           expect(RESULT[0]).toEqual({ id: 'a', error: 'Alpha is required' });
           expect(RESULT[1]).toEqual({ id: 'b', error: 'Bravo is required' });
@@ -109,7 +113,11 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.TEXT, 'Bravo', true),
             setup('charlie', ComponentTypes.TEXT, 'Charlie', true)
           ];
-          const RESULT = validatePage(COMPONENTS, DATA, []);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: null
+          };
+          const RESULT = validatePage(PAGE);
           expect(RESULT.length).toEqual(1);
           expect(RESULT[0]).toEqual({
             id: 'charlie',

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -13,7 +13,14 @@ describe('utils', () => {
       };
 
       it('should return no error when the components array is null', () => {
-        expect(validatePage(null).length).toEqual(0);
+        const PAGE = {
+          components: null,
+          formData: {
+            alpha: 'alpha.smith@digital.homeoffice.gov.uk',
+            bravo: 'bravo.jones@digital.homeoffice.gov.uk'
+          }
+        };
+        expect(validatePage(PAGE).length).toEqual(0);
       });
 
       it('should return no error when the components array is empty', () => {

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -15,10 +15,7 @@ describe('utils', () => {
       it('should return no error when the components array is null', () => {
         const PAGE = {
           components: null,
-          formData: {
-            alpha: 'alpha.smith@digital.homeoffice.gov.uk',
-            bravo: 'bravo.jones@digital.homeoffice.gov.uk'
-          }
+          formData: {}
         };
         expect(validatePage(PAGE).length).toEqual(0);
       });

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -38,7 +38,7 @@ describe('utils', () => {
             setup('d', ComponentTypes.TEXT, 'Delta', true),
             setup('e', ComponentTypes.TEXT, 'Echo', true)
           ];
-          const RESULT = validatePage(COMPONENTS, null);
+          const RESULT = validatePage(COMPONENTS, null, []);
           expect(RESULT.length).toEqual(4);
           expect(RESULT[0]).toEqual({ id: 'a', error: 'Alpha is required' });
           expect(RESULT[1]).toEqual({ id: 'b', error: 'Bravo is required' });
@@ -109,7 +109,7 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.TEXT, 'Bravo', true),
             setup('charlie', ComponentTypes.TEXT, 'Charlie', true)
           ];
-          const RESULT = validatePage(COMPONENTS, DATA);
+          const RESULT = validatePage(COMPONENTS, DATA, []);
           expect(RESULT.length).toEqual(1);
           expect(RESULT[0]).toEqual({
             id: 'charlie',
@@ -123,7 +123,7 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.EMAIL, 'Bravo', false),
             setup('charlie', ComponentTypes.EMAIL, 'Charlie', false)
           ];
-          const RESULT = validatePage(COMPONENTS, DATA);
+          const RESULT = validatePage(COMPONENTS, DATA, []);
           expect(RESULT.length).toEqual(1);
           expect(RESULT[0]).toEqual({
             id: 'bravo',
@@ -137,7 +137,7 @@ describe('utils', () => {
             setup('bravo', ComponentTypes.EMAIL, 'Bravo', true),
             setup('charlie', ComponentTypes.EMAIL, 'Charlie', true)
           ];
-          const RESULT = validatePage(COMPONENTS, DATA);
+          const RESULT = validatePage(COMPONENTS, DATA, []);
           expect(RESULT.length).toEqual(2);
           expect(RESULT[0]).toEqual({
             id: 'bravo',

--- a/src/utils/Validate/validatePage.test.js
+++ b/src/utils/Validate/validatePage.test.js
@@ -17,7 +17,11 @@ describe('utils', () => {
       });
 
       it('should return no error when the components array is empty', () => {
-        expect(validatePage(null).length).toEqual(0);
+        const PAGE = {
+          components: [],
+          formData: null
+        };
+        expect(validatePage(PAGE).length).toEqual(0);
       });
 
       describe('when there is no form data', () => {
@@ -79,15 +83,24 @@ describe('utils', () => {
             setup('alpha', ComponentTypes.TEXT, 'Alpha', true),
             setup('bravo', ComponentTypes.TEXT, 'Bravo', true)
           ];
-          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: DATA
+          };
+          expect(validatePage(PAGE).length).toEqual(0);
         });
+
 
         it('should return no errors when none of the components are required but are all email types', () => {
           const COMPONENTS = [
             setup('alpha', ComponentTypes.EMAIL, 'Alpha', false),
             setup('bravo', ComponentTypes.EMAIL, 'Bravo', false)
           ];
-          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: DATA
+          };
+          expect(validatePage(PAGE).length).toEqual(0);
         });
 
         it('should return no errors when all of the components are required and email types', () => {
@@ -95,7 +108,11 @@ describe('utils', () => {
             setup('alpha', ComponentTypes.EMAIL, 'Alpha', true),
             setup('bravo', ComponentTypes.EMAIL, 'Bravo', true)
           ];
-          expect(validatePage(COMPONENTS, DATA).length).toEqual(0);
+          const PAGE = {
+            components: COMPONENTS,
+            formData: DATA
+          };
+          expect(validatePage(PAGE).length).toEqual(0);
         });
 
       });


### PR DESCRIPTION
In the current build validation occurs on required fields during the "check your answers" page even when the page that they belong to has not been displayed due to conditional logic on the page itself. A work around to this is possible by passing the same conditional "show-when" on the components as the page has however this is not ideal and quite difficult to document.

The below changes adds an additional step when validating a page to first check whether or not the page was actually displayed to the user.

Jira ticket link - https://support.cop.homeoffice.gov.uk/browse/CO-2120