### PR TITLE
added optional description text and screen reader text for blank answers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/CheckYourAnswers/Answer.jsx
+++ b/src/components/CheckYourAnswers/Answer.jsx
@@ -9,7 +9,6 @@ import FormComponent from '../FormComponent';
 const Answer = ({ value, component }) => {
   if (!value) {
    return <VisuallyHidden>No answer</VisuallyHidden>;
-   // return 'test text';
   }
   if (!component) {
     return value;

--- a/src/components/CheckYourAnswers/Answer.jsx
+++ b/src/components/CheckYourAnswers/Answer.jsx
@@ -1,13 +1,15 @@
 // Global imports
 import PropTypes from 'prop-types';
 import React from 'react';
+import VisuallyHidden from '@ukhomeoffice/cop-react-components/dist/VisuallyHidden';
 
 // Local imports
 import FormComponent from '../FormComponent';
 
 const Answer = ({ value, component }) => {
   if (!value) {
-    return null;
+   return <VisuallyHidden>No answer</VisuallyHidden>;
+   // return 'test text';
   }
   if (!component) {
     return value;

--- a/src/components/CheckYourAnswers/Answer.test.js
+++ b/src/components/CheckYourAnswers/Answer.test.js
@@ -16,7 +16,8 @@ describe('components', () => {
       const { container } = render(
         <Answer value={VALUE} component={COMPONENT} />
       );
-      expect(container.childNodes.length).toEqual(0);
+      expect(container.childNodes.length).toEqual(1);
+      expect(container.childNodes[0].textContent).toEqual('No answer');
     });
 
     it('should handle a null component', async () => {

--- a/src/components/CheckYourAnswers/CheckYourAnswers.test.js
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.test.js
@@ -159,14 +159,14 @@ describe('components', () => {
 
       const firstNameRow = namesGroup.childNodes[0].childNodes[0];
       expect(firstNameRow.childNodes.length).toEqual(2);
-      expect(firstNameRow.childNodes[0].textContent).toEqual('First name');
+      expect(firstNameRow.childNodes[0].textContent).toEqual('First name (optional)');
       expect(firstNameRow.childNodes[0].tagName).toEqual('DT');
       expect(firstNameRow.childNodes[1].textContent).toEqual('John');
       expect(firstNameRow.childNodes[1].tagName).toEqual('DD');
 
       const surname = namesGroup.childNodes[0].childNodes[1];
       expect(surname.childNodes.length).toEqual(2);
-      expect(surname.childNodes[0].textContent).toEqual('Last name');
+      expect(surname.childNodes[0].textContent).toEqual('Last name (optional)');
       expect(surname.childNodes[0].tagName).toEqual('DT');
       expect(surname.childNodes[1].textContent).toEqual('Smith');
       expect(surname.childNodes[1].tagName).toEqual('DD');

--- a/src/components/SummaryList/SummaryList.jsx
+++ b/src/components/SummaryList/SummaryList.jsx
@@ -26,7 +26,10 @@ const SummaryList = ({
     <dl {...attrs} className={classes()}>
       {rows.map((row) =>  
           <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
-            <dt className={classes('key')}>{row.key}</dt>
+          <dt className={classes('key')}>
+            {row.key}
+            {!row.component?.required && ` (optional)`}
+          </dt>
             <dd className={classes('value')}>{row.value}</dd>
             {!noChangeAction && (
               <dd className={classes('actions')}>

--- a/src/components/SummaryList/SummaryList.test.js
+++ b/src/components/SummaryList/SummaryList.test.js
@@ -64,7 +64,7 @@ describe('components', () => {
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
         const [key, value, actions] = checkRow(summaryList, index);
-        expect(key.textContent).toEqual(row.key);
+        expect(key.textContent).toEqual(`${row.key} (optional)`);
         expect(value.textContent).toEqual(row.value);
         expect(actions.childNodes.length).toEqual(0);
       });
@@ -94,7 +94,7 @@ describe('components', () => {
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
         const [key, value, actions] = checkRow(summaryList, index);
-        expect(key.textContent).toEqual(row.key);
+        expect(key.textContent).toEqual(`${row.key} (optional)`);
         expect(value.childNodes.length).toEqual(1);
         const valueDiv = value.childNodes[0];
         expect(valueDiv.tagName).toEqual('DIV');
@@ -132,7 +132,7 @@ describe('components', () => {
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
         const [key, value, actions] = checkRow(summaryList, index);
-        expect(key.textContent).toEqual(row.key);
+        expect(key.textContent).toEqual(`${row.key} (optional)`);
         expect(value.textContent).toEqual(row.value);
         const a = actions.childNodes[0];
         expect(a.textContent).toEqual(row.action.label);
@@ -166,7 +166,7 @@ describe('components', () => {
       expect(summaryList.childNodes.length).toEqual(ROWS.length);
       ROWS.forEach((row, index) => {
         const [key, value] = checkRowNoChangeActions(summaryList, index);
-        expect(key.textContent).toEqual(row.key);
+        expect(key.textContent).toEqual(`${row.key} (optional)`);
         expect(value.childNodes.length).toEqual(1);
         const valueDiv = value.childNodes[0];
         expect(valueDiv.tagName).toEqual('DIV');
@@ -205,7 +205,7 @@ describe('components', () => {
       expect(summaryList.childNodes.length).toEqual(ROWS.length + 1);
       ROWS.forEach((row, index) => {
         const [key, value] = checkRow(summaryList, index);
-        expect(key.textContent).toEqual(row.key);
+        expect(key.textContent).toEqual(`${row.key} (optional)`);
         expect(value.childNodes.length).toEqual(1);
         const valueDiv = value.childNodes[0];
         expect(valueDiv.tagName).toEqual('DIV');


### PR DESCRIPTION
**Description**

Added `(optional)` to the key in check your answers screen when fields are not set to `required:true`. Also added a `VisuallyHidden` component to the check answers screen when optional questions are not filled in. Unit tests have been modified to reflect those changes

https://support.cop.homeoffice.gov.uk/browse/COP-10811

**To test**
Covered by unit tests.