### PR TITLE
COP-10873: Add collection validation

### DIFF
--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -1,5 +1,6 @@
 const TYPE_AUTOCOMPLETE = 'autocomplete';
 const TYPE_CHECKBOXES = 'checkboxes';
+const TYPE_COLLECTION = 'collection';
 const TYPE_CONTAINER = 'container';
 const TYPE_DATE = 'date';
 const TYPE_EMAIL = 'email';
@@ -16,6 +17,7 @@ const TYPE_TIME = 'time'
 const ComponentTypes = {
   AUTOCOMPLETE: TYPE_AUTOCOMPLETE,
   CHECKBOXES: TYPE_CHECKBOXES,
+  COLLECTION: TYPE_COLLECTION,
   CONTAINER: TYPE_CONTAINER,
   DATE: TYPE_DATE,
   EMAIL: TYPE_EMAIL,

--- a/src/utils/Validate/validateCollection.js
+++ b/src/utils/Validate/validateCollection.js
@@ -1,0 +1,24 @@
+// Local imports
+import validateContainer from './validateContainer';
+
+const validateCollection = (collection, items) => {
+  const errors = [];
+  if (collection && Array.isArray(collection.item) && Array.isArray(items)) {
+    items.forEach((item, index) => {
+      const full_path = `${collection.full_path || collection.fieldId}[${index}]`;
+      const container = {
+        full_path,
+        components: collection.item.map(component => {
+          return {
+            ...component,
+            full_path: `${full_path}.${component.fieldId}`
+          };
+        })
+      };
+      errors.push(validateContainer(container, item));
+    });
+  }
+  return errors.filter(e => !!e).flat();
+};
+
+export default validateCollection;

--- a/src/utils/Validate/validateCollection.test.js
+++ b/src/utils/Validate/validateCollection.test.js
@@ -1,0 +1,77 @@
+// Local imports
+import { ComponentTypes } from '../../models';
+import validateCollection from './validateCollection';
+
+describe('utils.Validate.Collection', () => {
+
+  const setup = (id, type, label, required, item) => {
+    return { id, fieldId: id, type, label, required, item };
+  };
+
+  it('should return an empty array when the component is null', () => {
+    expect(validateCollection(null, [])).toEqual([]);
+  });
+
+  it('should return an empty array when the collection has an undefined item array', () => {
+    const ID = 'collection';
+    const LABEL = 'field';
+    const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false, undefined);
+    expect(validateCollection(COLLECTION, [])).toEqual([]);
+  });
+
+  it('should return an empty array when the collection has an empty item array', () => {
+    const ID = 'collection';
+    const LABEL = 'field';
+    const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false, []);
+    expect(validateCollection(COLLECTION, [])).toEqual([]);
+  });
+
+  it('should return an empty array when the collection has only valid items', () => {
+    const EMAIL_ID = 'email';
+    const EMAIL_LABEL = 'Email';
+    const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+    const ID = 'collection';
+    const LABEL = 'field';
+    const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false, [EMAIL]);
+    const ITEMS = [
+      { [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' },
+      { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }
+    ];
+    expect(validateCollection(COLLECTION, ITEMS)).toEqual([]);
+  });
+
+  it('should return an array containing an error when the collection has an invalid first item', () => {
+    const EMAIL_ID = 'email';
+    const EMAIL_LABEL = 'Email';
+    const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+    const ID = 'container';
+    const LABEL = 'field';
+    const COLLECTION = setup(ID, ComponentTypes.CONTAINER, LABEL, false, [EMAIL]);
+    const ITEMS = [
+      { [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.com' },
+      { [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk' }
+    ];
+    expect(validateCollection(COLLECTION, ITEMS)).toEqual([{
+      id: `${ID}[0].${EMAIL_ID}`,
+      error: `Enter ${EMAIL_LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
+    }]);
+  });
+
+  it('should return an array containing an error when the collection has an invalid second item', () => {
+    const EMAIL_ID = 'email';
+    const EMAIL_LABEL = 'Email';
+    const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+    const ID = 'container';
+    const LABEL = 'field';
+    const COLLECTION = setup(ID, ComponentTypes.CONTAINER, LABEL, false, [EMAIL]);
+    const ITEMS = [
+      { [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk' },
+      { [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.com' }
+    ];
+    expect(validateCollection(COLLECTION, ITEMS)).toEqual([{
+      id: `${ID}[1].${EMAIL_ID}`,
+      error: `Enter ${EMAIL_LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
+    }]);
+  });
+
+});

--- a/src/utils/Validate/validateContainer.js
+++ b/src/utils/Validate/validateContainer.js
@@ -1,0 +1,15 @@
+// Local imports
+import validateComponent from './validateComponent';
+
+const validateContainer = (container, formData) => {
+  const errors = [];
+  if (container && Array.isArray(container.components)) {
+    const fd = formData && container.fieldId ? formData[container.fieldId] : formData;
+    container.components.forEach(component => {
+      errors.push(validateComponent(component, fd));
+    });
+  }
+  return errors.filter(e => !!e);
+};
+
+export default validateContainer;

--- a/src/utils/Validate/validateContainer.test.js
+++ b/src/utils/Validate/validateContainer.test.js
@@ -1,0 +1,65 @@
+// Local imports
+import { ComponentTypes } from '../../models';
+import validateContainer from './validateContainer';
+
+describe('utils.Validate.Container', () => {
+
+  const setup = (id, type, label, required, additionalValidation) => {
+    return { id, fieldId: id, type, label, required, additionalValidation };
+  };
+
+  it('should return an empty array when the component is null', () => {
+    expect(validateContainer(null, {})).toEqual([]);
+  });
+
+  it('should return an empty array when the container has an undefined components array', () => {
+    const ID = 'container';
+    const LABEL = 'field';
+    const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
+    expect(validateContainer(CONTAINER, null)).toEqual([]);
+  });
+
+  it('should return an empty array when the container has no components', () => {
+    const ID = 'container';
+    const LABEL = 'field';
+    const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
+    CONTAINER.components = [];
+    expect(validateContainer(CONTAINER, null)).toEqual([]);
+  });
+
+  it('should return an empty array when the container has only valid components', () => {
+    const EMAIL_ID = 'email';
+    const EMAIL_LABEL = 'Email';
+    const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+    const ID = 'container';
+    const LABEL = 'field';
+    const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
+    CONTAINER.components = [EMAIL];
+    const DATA = {
+      [ID]: {
+        [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk'
+      }
+    };
+    expect(validateContainer(CONTAINER, DATA)).toEqual([]);
+  });
+
+  it('should return an array containing an error when the container has an invalid component', () => {
+    const EMAIL_ID = 'email';
+    const EMAIL_LABEL = 'Email';
+    const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+    const ID = 'container';
+    const LABEL = 'field';
+    const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
+    CONTAINER.components = [EMAIL];
+    const DATA = {
+      [ID]: {
+        [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.com'
+      }
+    };
+    expect(validateContainer(CONTAINER, DATA)).toEqual([{
+        id: EMAIL_ID,
+        error: `Enter ${EMAIL_LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
+    }]);
+  });
+
+});


### PR DESCRIPTION
### Description
Added validation for collections and also refactored the `validateComponent` and `validateContainer` methods so they're in their own files, rather than all bundled into one.

https://support.cop.homeoffice.gov.uk/browse/COP-10873

### To test
Covered by accompanying unit tests.