### PR TITLE
Add util function to get CYA rows for collection

### DIFF
--- a/src/components/SummaryList/SummaryList.jsx
+++ b/src/components/SummaryList/SummaryList.jsx
@@ -28,8 +28,7 @@ const SummaryList = ({
           <div key={`${row.pageId}_${row.fieldId}`} className={classes('row')}>
             <dt className={classes('key')}>
               {row.key}
-              {!row.hasOwnProperty('required') && !row.component?.required && ` (optional)`}
-              {!row.hasOwnProperty('component') && row.hasOwnProperty('required') && !row?.required && ` (optional)`}
+              {!row?.required && ` (optional)`}
             </dt>
             <dd className={classes('value')}>{row.value}</dd>
             {!noChangeAction && (

--- a/src/models/CollectionLabels.js
+++ b/src/models/CollectionLabels.js
@@ -1,0 +1,8 @@
+const CollectionLabels = {
+  add: 'Add another',
+  remove: 'Remove',
+  // eslint-disable-next-line no-template-curly-in-string
+  item: 'Item ${index}'
+};
+
+export default CollectionLabels;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,4 +1,5 @@
 // Local imports
+import CollectionLabels from './CollectionLabels';
 import ComponentTypes from './ComponentTypes';
 import EventTypes from './EventTypes';
 import FormPages from './FormPages';
@@ -8,6 +9,7 @@ import PageAction from './PageAction';
 import TaskStates from './TaskStates';
 
 export {
+  CollectionLabels,
   ComponentTypes,
   EventTypes,
   FormPages,

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,7 @@
+import { ValidationContextProvider } from './context';
+
+export const expectObjectLike = (received, expected) => {
+  Object.keys(expected).forEach(key => {
+    expect(received[key]).toEqual(expected[key]);
+  });
+};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,3 @@
-import { ValidationContextProvider } from './context';
 
 export const expectObjectLike = (received, expected) => {
   Object.keys(expected).forEach(key => {

--- a/src/utils/CheckYourAnswers/getCYARow.js
+++ b/src/utils/CheckYourAnswers/getCYARow.js
@@ -23,7 +23,9 @@ const getCYARow = (page, component, onAction) => {
     pageId: page.id,
     id: component.id,
     fieldId: component.fieldId,
+    full_path: component.full_path,
     key: component.label || component.cya_label,
+    required: component.required,
     component: Component.editable(component) ? component : undefined,
     value: value || '',
     action: getCYAAction(component.readonly, page, onAction)

--- a/src/utils/CheckYourAnswers/getCYARow.test.js
+++ b/src/utils/CheckYourAnswers/getCYARow.test.js
@@ -1,4 +1,5 @@
 // Local imports
+import { expectObjectLike } from '../../setupTests';
 import getCYARow from './getCYARow';
 
 describe('utils', () => {
@@ -6,12 +7,6 @@ describe('utils', () => {
   describe('CheckYourAnswers', () => {
     
     describe('getCYARow', () => {
-
-      const expectObjectLike = (received, expected) => {
-        Object.keys(expected).forEach(key => {
-          expect(received[key]).toEqual(expected[key]);
-        });
-      };
 
       it('should get an appropriate row for a readonly text component', () => {
         const PAGE = { id: 'page', formData: { a: 'Bravo' } };

--- a/src/utils/CheckYourAnswers/getCYARowsForCollection.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForCollection.js
@@ -1,0 +1,55 @@
+// Global imports
+import { Utils } from '@ukhomeoffice/cop-react-components';
+
+// Local imports
+import { ComponentTypes } from '../../models';
+import getCYARowsForContainer from './getCYARowsForContainer';
+import showComponentCYA from './showComponentCYA';
+
+const getContainerForItem = (collection, item, labelCount, full_path) => {
+  return {
+    id: item.id,
+    fieldId: item.id,
+    type: ComponentTypes.CONTAINER,
+    required: collection.required,
+    full_path,
+    components: collection.item.map(component => {
+      return {
+        ...component,
+        label: Utils.interpolateString(component.label, { ...item, index: labelCount }),
+        full_path: `${full_path}.${component.fieldId}`
+      };
+    })
+  };
+};
+
+const getTitleRowForItem = (collection, item, pageId, labelCount, full_path) => {
+  if (collection.itemLabel) {
+    return {
+      pageId,
+      fieldId: collection.fieldId,
+      full_path: full_path,
+      key: Utils.interpolateString(collection.itemLabel, { ...item, index: labelCount }),
+      type: 'title',
+      action: null
+    };
+  }
+  return null;
+};
+
+const getCYARowsForCollection = (page, collection, items, onAction) => {
+  if (Array.isArray(items) && showComponentCYA(collection, page.formData)) {
+    return items.flatMap((item, index) => {
+      const labelCount = (collection.countOffset || 0) + index + 1;
+      const full_path = `${collection.full_path || collection.fieldId}[${index}]`;
+      const container = getContainerForItem(collection, item, labelCount, full_path);
+      return [
+        getTitleRowForItem(collection, item, page.id, labelCount, full_path),
+        ...getCYARowsForContainer(page, container, item, onAction)
+      ];
+    }).filter(r => !!r);
+  }
+  return [];
+};
+
+export default getCYARowsForCollection;

--- a/src/utils/CheckYourAnswers/getCYARowsForCollection.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForCollection.js
@@ -2,7 +2,7 @@
 import { Utils } from '@ukhomeoffice/cop-react-components';
 
 // Local imports
-import { ComponentTypes } from '../../models';
+import { CollectionLabels, ComponentTypes } from '../../models';
 import getCYARowsForContainer from './getCYARowsForContainer';
 import showComponentCYA from './showComponentCYA';
 
@@ -24,12 +24,16 @@ const getContainerForItem = (collection, item, labelCount, full_path) => {
 };
 
 const getTitleRowForItem = (collection, item, pageId, labelCount, full_path) => {
-  if (collection.itemLabel) {
+  const labels = {
+    ...CollectionLabels,
+    ...collection.labels
+  };
+  if (labels.item) {
     return {
       pageId,
       fieldId: collection.fieldId,
       full_path: full_path,
-      key: Utils.interpolateString(collection.itemLabel, { ...item, index: labelCount }),
+      key: Utils.interpolateString(labels.item, { ...item, index: labelCount }),
       type: 'title',
       action: null
     };

--- a/src/utils/CheckYourAnswers/getCYARowsForCollection.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForCollection.test.js
@@ -32,7 +32,6 @@ describe('utils.CheckYourAnswers.getCYARowsForCollection', () => {
       id: 'collection',
       fieldId: 'collection',
       type: ComponentTypes.COLLECTION,
-      itemLabel: 'Item ${index}',
       countOffset: 22,
       item: [ COMPONENT ],
       value: FORM_DATA.collection,
@@ -63,7 +62,7 @@ describe('utils.CheckYourAnswers.getCYARowsForCollection', () => {
     });
   });
 
-  it('should get an appropriate row for a collection with a single readonly text component where there is no itemLabel', () => {
+  it('should get an appropriate row for a collection with a single readonly text component where the item label is an empty string', () => {
     const FORM_DATA = {
       collection: [
         { a: 'Bravo' }
@@ -75,6 +74,9 @@ describe('utils.CheckYourAnswers.getCYARowsForCollection', () => {
       id: 'collection',
       fieldId: 'collection',
       type: ComponentTypes.COLLECTION,
+      labels: {
+        item: ''
+      },
       countOffset: 22,
       item: [ COMPONENT ],
       value: FORM_DATA.collection,
@@ -104,6 +106,7 @@ describe('utils.CheckYourAnswers.getCYARowsForCollection', () => {
       ]
     };
     const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    // eslint-disable-next-line no-template-curly-in-string
     const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha ${index}' };
     const COLLECTION = {
       id: 'collection',
@@ -115,8 +118,8 @@ describe('utils.CheckYourAnswers.getCYARowsForCollection', () => {
     };
     const ON_ACTION = () => {};
     const ROWS = getCYARowsForCollection(PAGE, COLLECTION, FORM_DATA.collection, ON_ACTION);
-    expect(ROWS.length).toEqual(1); // Just the component row, no title row
-    expectObjectLike(ROWS[0], {
+    expect(ROWS.length).toEqual(2); // Title and item row.
+    expectObjectLike(ROWS[1], {
       pageId: PAGE.id,
       fieldId: COMPONENT.fieldId,
       full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,

--- a/src/utils/CheckYourAnswers/getCYARowsForCollection.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForCollection.test.js
@@ -1,0 +1,134 @@
+// Local imports
+import { ComponentTypes } from '../../models';
+import { expectObjectLike } from '../../setupTests';
+import getCYARowsForCollection from './getCYARowsForCollection';
+
+describe('utils.CheckYourAnswers.getCYARowsForCollection', () => {
+
+  it('should get no rows when there are no items', () => {
+    const FORM_DATA = undefined;
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+    const COLLECTION = {
+      id: 'collection',
+      fieldId: 'collection',
+      type: ComponentTypes.COLLECTION,
+      item: [ COMPONENT ]
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForCollection(PAGE, COLLECTION, undefined, ON_ACTION);
+    expect(ROWS.length).toEqual(0);
+  });
+
+  it('should get an appropriate row for a collection with a single readonly text component', () => {
+    const FORM_DATA = {
+      collection: [
+        { a: 'Bravo' }
+      ]
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+    const COLLECTION = {
+      id: 'collection',
+      fieldId: 'collection',
+      type: ComponentTypes.COLLECTION,
+      itemLabel: 'Item ${index}',
+      countOffset: 22,
+      item: [ COMPONENT ],
+      value: FORM_DATA.collection,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForCollection(PAGE, COLLECTION, FORM_DATA.collection, ON_ACTION);
+    expect(ROWS.length).toEqual(2); // Item title row + component row
+    expectObjectLike(ROWS[0], {
+      pageId: PAGE.id,
+      fieldId: COLLECTION.fieldId,
+      full_path: `${COLLECTION.fieldId}[0]`,
+      key: 'Item 23', // includes countOffset
+      type: 'title',
+      action: null
+    });
+    expectObjectLike(ROWS[1], {
+      pageId: PAGE.id,
+      fieldId: COMPONENT.fieldId,
+      full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,
+      key: COMPONENT.label,
+      action: null,
+      component: {
+        ...COMPONENT,
+        full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`
+      },
+      value: 'Bravo'
+    });
+  });
+
+  it('should get an appropriate row for a collection with a single readonly text component where there is no itemLabel', () => {
+    const FORM_DATA = {
+      collection: [
+        { a: 'Bravo' }
+      ]
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+    const COLLECTION = {
+      id: 'collection',
+      fieldId: 'collection',
+      type: ComponentTypes.COLLECTION,
+      countOffset: 22,
+      item: [ COMPONENT ],
+      value: FORM_DATA.collection,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForCollection(PAGE, COLLECTION, FORM_DATA.collection, ON_ACTION);
+    expect(ROWS.length).toEqual(1); // Just the component row, no title row
+    expectObjectLike(ROWS[0], {
+      pageId: PAGE.id,
+      fieldId: COMPONENT.fieldId,
+      full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,
+      key: COMPONENT.label,
+      action: null,
+      component: {
+        ...COMPONENT,
+        full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`
+      },
+      value: 'Bravo'
+    });
+  });
+
+  it('should interpolate a field label appropriately', () => {
+    const FORM_DATA = {
+      collection: [
+        { a: 'Bravo' }
+      ]
+    };
+    const PAGE = { id: 'page', formData: FORM_DATA, cya_link: {} };
+    const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha ${index}' };
+    const COLLECTION = {
+      id: 'collection',
+      fieldId: 'collection',
+      type: ComponentTypes.COLLECTION,
+      item: [ COMPONENT ],
+      value: FORM_DATA.collection,
+      formData: FORM_DATA
+    };
+    const ON_ACTION = () => {};
+    const ROWS = getCYARowsForCollection(PAGE, COLLECTION, FORM_DATA.collection, ON_ACTION);
+    expect(ROWS.length).toEqual(1); // Just the component row, no title row
+    expectObjectLike(ROWS[0], {
+      pageId: PAGE.id,
+      fieldId: COMPONENT.fieldId,
+      full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,
+      key: 'Alpha 1', // no countOffset
+      action: null,
+      component: {
+        ...COMPONENT,
+        full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,
+        label: 'Alpha 1', // no countOffset
+      },
+      value: 'Bravo'
+    });
+  });
+  
+});

--- a/src/utils/CheckYourAnswers/getCYARowsForContainer.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForContainer.test.js
@@ -1,14 +1,9 @@
 // Local imports
 import { ComponentTypes } from '../../models';
+import { expectObjectLike } from '../../setupTests';
 import getCYARowsForContainer from './getCYARowsForContainer';
 
 describe('utils.CheckYourAnswers.getCYARowsForContainer', () => {
-
-  const expectObjectLike = (received, expected) => {
-    Object.keys(expected).forEach(key => {
-      expect(received[key]).toEqual(expected[key]);
-    });
-  };
 
   it('should get an appropriate row for a container with a single readonly text component', () => {
     const FORM_DATA = {

--- a/src/utils/CheckYourAnswers/getCYARowsForPage.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForPage.js
@@ -3,6 +3,7 @@ import { ComponentTypes } from '../../models';
 import FormPage from '../FormPage';
 import getCYARow from './getCYARow';
 import getCYARowForGroup from './getCYARowForGroup';
+import getCYARowsForCollection from './getCYARowsForCollection';
 import getCYARowsForContainer from './getCYARowsForContainer';
 import showComponentCYA from './showComponentCYA';
 
@@ -17,10 +18,14 @@ import showComponentCYA from './showComponentCYA';
 const getCYARowsForPage = (page, onAction) => {
   if (FormPage.show(page, page.formData)) {
     const rows = page.components.filter(c => showComponentCYA(c, page.formData)).flatMap(component => {
-      if (component.type === ComponentTypes.CONTAINER) {
-        return getCYARowsForContainer(page, component, page.formData[component.fieldId], onAction);
+      switch (component.type) {
+        case ComponentTypes.CONTAINER:
+          return getCYARowsForContainer(page, component, page.formData[component.fieldId], onAction);
+        case ComponentTypes.COLLECTION:
+          return getCYARowsForCollection(page, component, page.formData[component.fieldId], onAction);
+        default:
+          return getCYARow(page, component, onAction);
       }
-      return getCYARow(page, component, onAction);
     });
 
     if (page.groups?.length > 0) {

--- a/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
@@ -1,7 +1,8 @@
 // Global imports
-import {render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 // Local imports
+import { expectObjectLike } from '../../setupTests';
 import { ComponentTypes } from '../../models';
 import getCYARowsForPage from './getCYARowsForPage';
 
@@ -10,12 +11,6 @@ describe('utils', () => {
   describe('CheckYourAnswers', () => {
     
     describe('getCYARowsForPage', () => {
-
-      const expectObjectLike = (received, expected) => {
-        Object.keys(expected).forEach(key => {
-          expect(received[key]).toEqual(expected[key]);
-        });
-      };
 
       it('should get a appropriate row for a page with a single readonly text component', () => {
         const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
@@ -121,7 +116,7 @@ describe('utils', () => {
             value: 'Bravo'
           });
         });
-      }); 
+      });
 
       it('Add ability to display answers from multiple fields in a single row', () => {
         const COMPONENT_ADDRESS = {id: 'firstLineOfTheAddress', fieldId: 'firstLineOfTheAddress', label: 'address', type: 'text'};
@@ -161,6 +156,43 @@ describe('utils', () => {
         expect(addressValues[1].childNodes[0].textContent).toEqual('City of Westminster')
         expect(addressValues[2].childNodes[0].textContent).toEqual('London')
         expect(addressValues[3].childNodes[0].textContent).toEqual('SW1A 2AA')
+      });
+
+      it('should get a appropriate row for a page with a single readonly text component within a collection', () => {
+        const FORM_DATA = {
+          collection: [
+            { a: 'Bravo' }
+          ]
+        };
+        const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha' };
+        const COLLECTION = {
+          id: 'collection',
+          fieldId: 'collection',
+          type: ComponentTypes.COLLECTION,
+          item: [ COMPONENT ],
+          value: FORM_DATA.collection,
+          formData: FORM_DATA
+        };
+        const PAGE = {
+          id: 'page',
+          components: [ COLLECTION ],
+          formData: FORM_DATA
+        };
+        const ON_ACTION = () => {};
+        const ROWS = getCYARowsForPage(PAGE, ON_ACTION);
+        expect(ROWS.length).toEqual(1); // No title row as there is no itemLabel
+        expectObjectLike(ROWS[0], {
+          pageId: PAGE.id,
+          fieldId: COMPONENT.fieldId,
+          full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,
+          key: COMPONENT.label,
+          action: null,
+          component: {
+            ...COMPONENT,
+            full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`
+          },
+          value: 'Bravo'
+        });
       });
 
     });

--- a/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
@@ -158,7 +158,7 @@ describe('utils', () => {
         expect(addressValues[3].childNodes[0].textContent).toEqual('SW1A 2AA')
       });
 
-      it('should get a appropriate row for a page with a single readonly text component within a collection', () => {
+      it('should get appropriate rows for a page with a single readonly text component within a collection', () => {
         const FORM_DATA = {
           collection: [
             { a: 'Bravo' }
@@ -180,8 +180,8 @@ describe('utils', () => {
         };
         const ON_ACTION = () => {};
         const ROWS = getCYARowsForPage(PAGE, ON_ACTION);
-        expect(ROWS.length).toEqual(1); // No title row as there is no itemLabel
-        expectObjectLike(ROWS[0], {
+        expect(ROWS.length).toEqual(2); // Title and item row
+        expectObjectLike(ROWS[1], {
           pageId: PAGE.id,
           fieldId: COMPONENT.fieldId,
           full_path: `${COLLECTION.fieldId}[0].${COMPONENT.fieldId}`,


### PR DESCRIPTION
### Description
Added a utility function to get Check your answers rows for collections of items. This also necessitated some changes to other utility functions for getting CYA rows.

https://support.cop.homeoffice.gov.uk/browse/COP-10873

### To test
Covered by accompanying unit tests.