### PR TITLE
COP-10873: Refactor validation

### DIFF
--- a/src/components/CheckYourAnswers/CheckYourAnswers.jsx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useEffect, useState } from 'react';
 
 // Local imports
+import { useValidation } from '../../hooks';
 import Utils from '../../utils';
 import PageActions from '../PageActions';
 import SummaryList from '../SummaryList';
@@ -33,8 +34,8 @@ const CheckYourAnswers = ({
   groups
 }) => {
   const [pages, setPages] = useState([]);
-  const [errors, setErrors] = useState([]);
   const [listOfGroups, setListOfGroups] = useState([]);
+  const { errors } = useValidation();
 
   useEffect(() => {
     const getRows = (page, pageIndex) => {
@@ -64,10 +65,6 @@ const CheckYourAnswers = ({
   const listMarginBottom = hide_page_titles ? 0 : DEFAULT_MARGIN_BOTTOM;
   const isLastPage = (index) => {
     return index === pages.length - 1;
-  };
-
-  const onError = (errors) => {
-    setErrors(errors);
   };
 
   useEffect(() => {
@@ -131,13 +128,7 @@ const CheckYourAnswers = ({
               )}
               {(isGroup(page.id)) && (
                 <div className='group-title'>
-                  <MediumHeading>
-                {(currentGroup.title ? (
-                  currentGroup.title
-                    ) : (
-                  page.title
-                ))}
-                  </MediumHeading>
+                  <MediumHeading>{currentGroup.title || page.title}</MediumHeading>
                 </div>)}
               <SummaryList
                 className={className}
@@ -152,7 +143,7 @@ const CheckYourAnswers = ({
       {!hide_actions && (
         <PageActions
           actions={actions}
-          onAction={(action) => onAction(action, onError)}
+          onAction={(action) => onAction(action)}
         />
       )}
     </div>

--- a/src/components/CheckYourAnswers/CheckYourAnswers.test.js
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.test.js
@@ -2,7 +2,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import { unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
 
 // Local imports
@@ -14,6 +14,7 @@ import USER_PROFILE from '../../json/userProfile.json';
 import GROUPED_ADDRESS_DATA_JSON from '../../json/group.data.json';
 import GROUPED_ADDRESS from '../../json/group.json';
 import GROUP_ROWS from '../../json/groupOfRow.json';
+import { renderDomWithValidation } from '../../setupTests';
 import Utils from '../../utils';
 import CheckYourAnswers, { DEFAULT_CLASS, DEFAULT_MARGIN_BOTTOM, DEFAULT_TITLE } from './CheckYourAnswers';
 
@@ -75,7 +76,10 @@ describe('components', () => {
 
     it('should show default title if none is provided', async () => {
       await act(async () => {
-        render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />,
+          container
+        );
       });
       const cya = checkCYA(container);
       const title = cya.childNodes[0];
@@ -86,7 +90,10 @@ describe('components', () => {
     it('should allow title to be overridden', async () => {
       const TITLE = 'Alpha Bravo Charlie';
       await act(async () => {
-        render(<CheckYourAnswers title={TITLE} pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers title={TITLE} pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />,
+          container
+        );
       });
       const cya = checkCYA(container);
       const title = cya.childNodes[0];
@@ -96,7 +103,10 @@ describe('components', () => {
 
     it('should show readonly page components correctly', async () => {
       await act(async () => {
-        render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />,
+          container
+        );
       });
       const cya = checkCYA(container);
       const [, cyaChildNode] = cya.childNodes;
@@ -110,7 +120,10 @@ describe('components', () => {
 
     it('should show editable page components correctly', async () => {
       await act(async () => {
-        render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />,
+          container
+        );
       });
       const cya = checkCYA(container);
       const [, , title, cyaChildNode] = cya.childNodes;
@@ -124,7 +137,10 @@ describe('components', () => {
 
     it('should show editable page components correctly with page titles hidden', async () => {
       await act(async () => {
-        render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_page_titles={true} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_page_titles={true} />,
+          container
+        );
       });
       const cya = checkCYA(container);
       const [, , cyaChildNode] = cya.childNodes; // The title simply isn't returned
@@ -137,7 +153,10 @@ describe('components', () => {
 
     it('should show no title if is set to hidden', async () => {
       await act(async () => {
-        render(<CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_title={true} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_title={true}/>,
+          container
+        );
       });
       const cya = checkCYA(container);
       const [cyaChildNode] = cya.childNodes;
@@ -154,7 +173,10 @@ describe('components', () => {
       const GROUP_PAGES = Utils.FormPage.getAll(GROUPED_ADDRESS.pages, GROUPED_ADDRESS.components, { ...DATA });
 
       await act(async () => {
-        render(<CheckYourAnswers pages={GROUP_PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_title={true} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={GROUP_PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} hide_title={true} />,
+          container
+        );
       });
 
       const cya = checkCYA(container);
@@ -182,7 +204,10 @@ describe('components', () => {
       const GROUP_PAGES = Utils.FormPage.getAll(GROUP_ROWS.pages, GROUP_ROWS.components, { ...DATA });
 
       await act(async () => {
-        render(<CheckYourAnswers pages={GROUP_PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} groups={GROUP_ROWS.cya.groups} />, container);
+        renderDomWithValidation(
+          <CheckYourAnswers pages={GROUP_PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} groups={GROUP_ROWS.cya.groups} />,
+          container
+        );
       });
       const cya = checkCYA(container);
       const namesGroup = cya.childNodes[2];

--- a/src/components/FormComponent/FormComponent.jsx
+++ b/src/components/FormComponent/FormComponent.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 // Local imports
-import { STATUS_COMPLETE, useHooks, useRefData } from '../../hooks';
+import { STATUS_COMPLETE, useValidation, useHooks, useRefData } from '../../hooks';
 import { ComponentTypes } from '../../models';
 import Utils from '../../utils';
-
 import Collection from './Collection';
 import Container from './Container';
+import { getComponentError } from './helpers';
 
 const FormComponent = ({
   component,
@@ -19,6 +19,7 @@ const FormComponent = ({
   ...attrs
 }) => {
   const { hooks } = useHooks();
+  const validation = useValidation();
   const { data, status } = useRefData(component);
   const [ options, setOptions ] = useState([]);
   useEffect(() => {
@@ -81,6 +82,7 @@ const FormComponent = ({
     ...attrs,
     ...component,
     id: component.full_path || component.id,
+    ...getComponentError(component, validation?.errors),
     label: component.label || '',
     hint: component.hint || '',
     options,

--- a/src/components/FormComponent/FormComponent.test.js
+++ b/src/components/FormComponent/FormComponent.test.js
@@ -1,9 +1,9 @@
 // Global imports
-import { render } from '@testing-library/react';
 import React from 'react';
 
 // Local imports
 import { addHook, resetHooks } from '../../hooks/useHooks';
+import { renderWithValidation } from '../../setupTests';
 import FormComponent from './FormComponent';
 
 describe('components', () => {
@@ -19,7 +19,7 @@ describe('components', () => {
       const VALUE = 'Text value';
       const COMPONENT = { id: ID, fieldId: ID, type: 'text', label: 'Text component', hint: 'Text hint' };
       const ON_CHANGE = () => {};
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} value={VALUE} onChange={ON_CHANGE} />
       );
 
@@ -48,7 +48,7 @@ describe('components', () => {
       const VALUE = 'Text value';
       const COMPONENT = { id: ID, fieldId: ID, type: 'text', label: 'Text component', hint: 'Text hint' };
       const ON_CHANGE = () => {};
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} wrap={false} value={VALUE} onChange={ON_CHANGE} />
       );
 
@@ -63,7 +63,7 @@ describe('components', () => {
     it('should render an html component appropriately', async () => {
       const ID = 'component';
       const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} />
       );
       const p = container.childNodes[0];
@@ -77,7 +77,7 @@ describe('components', () => {
       });
       const ID = 'component';
       const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} />
       );
       const div = container.childNodes[0];
@@ -91,7 +91,7 @@ describe('components', () => {
       });
       const ID = 'component';
       const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} />
       );
       const p = container.childNodes[0];

--- a/src/components/FormPage/FormPage.jsx
+++ b/src/components/FormPage/FormPage.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
 // Local imports.
+import { useValidation } from '../../hooks';
 import Utils from '../../utils';
 import FormComponent from '../FormComponent';
 import PageActions from '../PageActions';
@@ -20,7 +21,7 @@ const FormPage = ({
   className
 }) => {
   const [patch, setPatch] = useState({});
-  const [errors, setErrors] = useState([]);
+  const { errors } = useValidation();
 
   /**
    * Handle the state of the data directly within the page.
@@ -35,24 +36,20 @@ const FormPage = ({
     }));
   };
 
-  const onError = (errors) => {
-    setErrors(errors);
-  };
-
   const classes = Utils.classBuilder(classBlock, classModifiers, className);
   return (
     <div className={classes('page')} key={page.id}>
       {page.title && <LargeHeading>{page.title}</LargeHeading>}
-      {errors && errors.length > 0 && <ErrorSummary errors={errors} />}
+      {errors?.length > 0 && <ErrorSummary errors={errors} />}
       {page.components.filter(c => Utils.Component.show(c, page.formData)).map((component, index) => (
         <FormComponent key={index}
           component={component}
           onChange={onPageChange}
-          value={page.formData[component.fieldId] || ''}
+          value={page.formData[component.fieldId]}
           formData={page.formData}
         />
       ))}
-      <PageActions actions={page.actions} onAction={(action) => onAction(action, patch, onError)} />
+      <PageActions actions={page.actions} onAction={(action) => onAction(action, patch)} />
     </div>
   );
 };

--- a/src/components/FormPage/FormPage.test.js
+++ b/src/components/FormPage/FormPage.test.js
@@ -1,13 +1,14 @@
 // Global imports
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
 
 // Local imports
 import { PageAction } from '../../models';
+import { renderWithValidation } from '../../setupTests';
 import { DEFAULT_LABEL } from '../PageActions/ActionButton';
 import FormPage, { DEFAULT_CLASS } from './FormPage';
 
-describe('components', () => {
+describe('components.FormPage', () => {
 
   describe('FormPage', () => {
 
@@ -31,7 +32,7 @@ describe('components', () => {
     });
 
     it('should render a submit page correctly', async () => {
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormPage page={PAGE} onAction={ON_ACTION} />
       );
       const page = container.childNodes[0];
@@ -67,7 +68,7 @@ describe('components', () => {
     });
 
     it('should handle a page change appropriately', async () => {
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormPage page={PAGE} onAction={ON_ACTION} />
       );
       const page = container.childNodes[0];
@@ -84,7 +85,7 @@ describe('components', () => {
     });
 
     it('should handle a page action appropriately', async () => {
-      const { container } = render(
+      const { container } = renderWithValidation(
         <FormPage page={PAGE} onAction={ON_ACTION} />
       );
       const page = container.childNodes[0];
@@ -104,44 +105,6 @@ describe('components', () => {
       expect(PAGE.formData.text).toEqual(NEW_VALUE);
       expect(ON_ACTION_CALLS[0].action).toEqual(PageAction.DEFAULTS.submit);
       expect(ON_ACTION_CALLS[0].patch).toEqual({ text: NEW_VALUE });
-    });
-
-    it('should display errors appropriately', async () => {
-      const ERRORS = [{ id: TEXT.id, error: 'Invalid value' }];
-      const THROW_ERROR_ON_ACTION = (action, patch, onError) => {
-        ON_ACTION_CALLS.push({ action, patch, onError });
-        onError(ERRORS);
-      };
-      const { container } = render(
-        <FormPage page={PAGE} onAction={THROW_ERROR_ON_ACTION} />
-      );
-      const page = container.childNodes[0];
-
-      // Change the input.
-      const input = page.childNodes[1].childNodes[2];
-      const NEW_VALUE = `${VALUE}.`;
-      const CHANGE_EVENT = { target: { name: TEXT.fieldId, value: NEW_VALUE } };
-      fireEvent.change(input, CHANGE_EVENT);
-
-      // Then click the action button, which should call the onError callback method.
-      const button = page.childNodes[2].childNodes[0];
-      fireEvent.click(button, {});
-
-      // And confirm the page error is now displayed.
-      const errorSummary = page.childNodes[1];
-      expect(errorSummary.tagName).toEqual('DIV');
-      expect(errorSummary.id).toEqual('error-summary');
-      expect(errorSummary.classList).toContain('govuk-error-summary');
-      const errorList = errorSummary.childNodes[1].childNodes[0];
-      expect(errorList.tagName).toEqual('UL');
-      expect(errorList.classList).toContain('govuk-error-summary__list');
-      expect(errorList.childNodes.length).toEqual(ERRORS.length);
-      const error = errorList.childNodes[0];
-      expect(error.tagName).toEqual('LI');
-      const errorLink = error.childNodes[0];
-      expect(errorLink.tagName).toEqual('A');
-      expect(errorLink.textContent).toEqual(ERRORS[0].error);
-      expect(errorLink.getAttribute('href')).toEqual(`#${ERRORS[0].id}`);
     });
 
   });

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 // Local imports
-import { useHooks } from '../../hooks';
+import { ValidationContextProvider } from '../../context';
+import { useHooks, useValidation } from '../../hooks';
 import { EventTypes, FormPages, FormTypes, HubFormats, PageAction, TaskStates } from '../../models';
 import Utils from '../../utils';
 import CheckYourAnswers from '../CheckYourAnswers';
@@ -16,8 +17,46 @@ import helpers from './helpers';
 // Styles
 import './FormRenderer.scss';
 
-export const DEFAULT_CLASS = 'hods-form';
 const FormRenderer = ({
+  title,
+  type,
+  components,
+  pages,
+  hub,
+  cya,
+  data,
+  hooks,
+  classBlock,
+  classModifiers,
+  className,
+  hide_title,
+  summaryListClassModifiers,
+  noChangeAction,
+}) => {
+  return (
+    <ValidationContextProvider>
+      <InternalFormRenderer
+        title={title}
+        type={type}
+        components={components}
+        pages={pages}
+        hub={hub}
+        cya={cya}
+        data={data}
+        hooks={hooks}
+        classBlock={classBlock}
+        classModifiers={classModifiers}
+        className={className}
+        hide_title={hide_title}
+        summaryListClassModifiers={summaryListClassModifiers}
+        noChangeAction={noChangeAction}
+      />
+    </ValidationContextProvider>
+  );
+};
+
+export const DEFAULT_CLASS = 'hods-form';
+const InternalFormRenderer = ({
   title,
   type,
   components,
@@ -35,6 +74,7 @@ const FormRenderer = ({
 }) => {
   // Set up the initial states.
   const [data, setData] = useState({});
+  const [submitted, setSubmitted] = useState();
   const [pages, setPages] = useState([]);
   const [hub, setHub] = useState(undefined);
   const [pageId, setPageId] = useState(helpers.getNextPageId(type, _pages));
@@ -51,6 +91,9 @@ const FormRenderer = ({
       });
     }
   }, [_hooks, addHook]);
+
+  // Set up the useValidation hook.
+  const { addErrors, clearErrors, validate } = useValidation();
 
   // Setup data.
   useEffect(() => {
@@ -93,6 +136,16 @@ const FormRenderer = ({
     setHubDetails(_hub);
   }, [_hub])
 
+  // Calling setData directly within the hooks.onSubmit success handler
+  // resulted in a sychronisation error. Handling it in a useEffect appears
+  // to be the way to deal with this... and it certainly seems to work.
+  useEffect(() => {
+    if (submitted?.data) {
+      setData(submitted.data);
+      setSubmitted(undefined);
+    }
+  }, [submitted, setData, setSubmitted]);
+
   // Update task list pages with form data and update states
   useEffect(() => {
     const pages = currentTask.fullPages;
@@ -111,15 +164,16 @@ const FormRenderer = ({
   }, [currentTask.fullPages, data, hubDetails?.sections]);
 
   const onPageChange = (newPageId) => {
+    clearErrors();
     setPageId(newPageId);
     hooks.onPageChange(newPageId);
   };
 
   // Handle actions from pages.
-  const onPageAction = (action, patch, onError) => {
+  const onPageAction = (action, patch) => {
     // Check to see whether the action is able to proceed, which in
     // in the case of a submission will validate the fields in the page.
-    if (helpers.canActionProceed(action, formState.page, onError)) {
+    if (helpers.canActionProceed(action, formState.page, validate.page)) {
       if (action.type === PageAction.TYPES.NAVIGATE) {
         handlers.navigate(action, pageId, onPageChange);
       } else {
@@ -131,20 +185,21 @@ const FormRenderer = ({
         }
 
         let pageUpdate = (next) => onPageChange(helpers.getNextPageId(type, pages, pageId, action, next));
+        // const navigablePages = currentTask?.fullPages || pages;
+        // let pageUpdate = (next) => onPageChange(helpers.getNextPageId(type, navigablePages, pageId, action, next));
         if (action.type === PageAction.TYPES.SAVE_AND_NAVIGATE) {
           pageUpdate = () => handlers.navigate(action, pageId, onPageChange);
         }
 
         // Now submit the data to the backend...
         hooks.onSubmit(action.type, submissionData, (response) => {
-          // The backend response may well contain data we need so apply it.
-          setData(prev => {
-            const next = { ...prev, ...response };
-            pageUpdate(next);
-            return next;
-          });
+          // The backend response may well contain data we need so apply it...
+          // ... but this needs to happen in a useEffect, not right away.
+          const sData = { ...submissionData, ...response };
+          setSubmitted({ data: sData });
+          pageUpdate(sData);
         }, (errors) => {
-          handlers.submissionError(errors, onError);
+          handlers.submissionError(errors, addErrors);
         });
       }
     }
@@ -177,11 +232,11 @@ const FormRenderer = ({
   };
 
   // Handle actions from "Check your answers".
-  const onCYAAction = (action, onError) => {
+  const onCYAAction = (action) => {
     // Check to see whether the action is able to proceed, which in
     // in the case of a submission will validate the fields in the page.
     if (action.type === PageAction.TYPES.SUBMIT) {
-      if (helpers.canCYASubmit(pages, onError)) {
+      if (helpers.canCYASubmit(pages, validate.pages)) {
         // Submit.
         const submissionData = Utils.Format.form({ pages, components }, { ...data }, EventTypes.SUBMIT);
         submissionData.formStatus = helpers.getSubmissionStatus(type, pages, pageId, action, submissionData, currentTask, true);
@@ -189,23 +244,23 @@ const FormRenderer = ({
         // Now submit the data to the backend...
         hooks.onSubmit(action.type, submissionData,
           () => hooks.onFormComplete(),
-          (errors) => handlers.submissionError(errors, onError)
+          (errors) => handlers.submissionError(errors, addErrors)
         );
       }
     }
     if (action.type === PageAction.TYPES.SAVE_AND_CONTINUE && hub === HubFormats.TASK) {
-      if (helpers.canCYASubmit(currentTask.fullPages, onError)) {
+      if (helpers.canCYASubmit(currentTask.fullPages, validate.pages)) {
         const submissionData = Utils.Format.form({ pages, components }, { ...data }, EventTypes.SUBMIT);
         submissionData.formStatus = helpers.getSubmissionStatus(type, pages, pageId, action, submissionData, currentTask, true);
         setData(submissionData);
         hooks.onSubmit(action.type, submissionData, 
           () => onPageChange(FormPages.HUB),
-          (errors) => handlers.submissionError(errors, onError)
+          (errors) => handlers.submissionError(errors, addErrors)
         );
       }
     }
     if (action.type === PageAction.TYPES.SAVE_AND_RETURN) {
-      if (helpers.canCYASubmit(currentTask.fullPages, onError)) {
+      if (helpers.canCYASubmit(currentTask.fullPages, validate.pages)) {
         const submissionData = Utils.Format.form({ pages, components }, { ...data }, EventTypes.SUBMIT);
         submissionData.formStatus = helpers.getSubmissionStatus(type, pages, pageId, action, submissionData, currentTask);
         setData(submissionData);
@@ -218,7 +273,7 @@ const FormRenderer = ({
               onPageChange(FormPages.HUB)
             }
           },
-          (errors) => handlers.submissionError(errors, onError)
+          (errors) => handlers.submissionError(errors, addErrors)
         );
       }
     }
@@ -263,7 +318,7 @@ const FormRenderer = ({
   );
 };
 
-FormRenderer.propTypes = {
+FormRenderer.propTypes = InternalFormRenderer.propTypes = {
   title: PropTypes.string,
   /** See <a href="/?path=/docs/f-json--page#formtypes">FormTypes</a>. */
   type: PropTypes.oneOf([FormTypes.CYA, FormTypes.FORM, FormTypes.HUB, FormTypes.TASK, FormTypes.WIZARD]).isRequired,
@@ -289,7 +344,7 @@ FormRenderer.propTypes = {
   noChangeAction: PropTypes.bool,
 };
 
-FormRenderer.defaultProps = {
+FormRenderer.defaultProps = InternalFormRenderer.defaultProps = {
   type: FormTypes.HUB,
   components: [],
   pages: [],

--- a/src/components/FormRenderer/helpers/canActionProceed.js
+++ b/src/components/FormRenderer/helpers/canActionProceed.js
@@ -1,20 +1,15 @@
-// Local imports
-import Utils from '../../../utils';
-
 /**
  * Assesses whether the action can proceed when navigating, submitting, etc.
  * Presently, this will validate a page when submitting and, only if the page is
  * valid will it proceed. If it's simple navigation, it simply returns true.
  * @param {object} action The action object we're assessing.
  * @param {object} page The page configuration object this action relates to.
- * @param {Function} onError A function to call with any validation errors.
+ * @param {Function} pageValidator A function to validate the page.
  * @returns A boolean where `true` means the action can proceed and `false` means it cannot.
  */
-const canActionProceed = (action, page, onError) => {
+const canActionProceed = (action, page, pageValidator) => {
   if (action.validate) {
-    const errors = Utils.Validate.page(page);
-    onError(errors);
-    return errors.length === 0;
+    return pageValidator(page).length === 0;
   }
   return true;
 };

--- a/src/components/FormRenderer/helpers/canActionProceed.test.js
+++ b/src/components/FormRenderer/helpers/canActionProceed.test.js
@@ -1,54 +1,36 @@
 // Local imports
+import Validate from '../../../utils/Validate';
 import canActionProceed from './canActionProceed';
 
-describe('components', () => {
+describe('components.FormRenderer.helpers.canActionProceed', () => {
 
-  describe('FormRenderer', () => {
+  it('should return true when the action does not require validation', () => {
+    const ACTION = { validate: false };
+    expect(canActionProceed(ACTION, {}, Validate.page)).toBeTruthy();
+  });
 
-    describe('helpers', () => {
+  it('should return true when the page is valid', () => {
+    const ACTION = { validate: true };
+    const PAGE = {
+      components: [
+        { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
+      ],
+      formData: {
+        a: 'Bravo'
+      }
+    };
+    expect(canActionProceed(ACTION, PAGE, Validate.page)).toBeTruthy();
+  });
 
-      describe('canActionProceed', () => {
-
-        it('should return true when the action does not require validation', () => {
-          const ACTION = { validate: false };
-          expect(canActionProceed(ACTION, {}, () => {})).toBeTruthy();
-        });
-
-        it('should return true when the page is valid', () => {
-          const ACTION = { validate: true };
-          const PAGE = {
-            components: [
-              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
-            ],
-            formData: {
-              a: 'Bravo'
-            }
-          };
-          expect(canActionProceed(ACTION, PAGE, () => {})).toBeTruthy();
-        });
-
-        it('should return false when the page is invalid and should have called the onErrors method appropriately', () => {
-          const ACTION = { validate: true };
-          const PAGE = {
-            components: [
-              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
-            ],
-            formData: {}
-          };
-          const ERRORS = [];
-          const ON_ERROR = (errors) => {
-            ERRORS.push(...errors);
-          };
-          expect(canActionProceed(ACTION, PAGE, ON_ERROR)).toBeFalsy();
-          expect(ERRORS.length).toEqual(1);
-          expect(ERRORS[0].id).toEqual('a');
-          expect(ERRORS[0].error).toEqual('Alpha is required');
-        });
-
-      });
-
-    });
-
+  it('should return false when the page is invalid', () => {
+    const ACTION = { validate: true };
+    const PAGE = {
+      components: [
+        { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
+      ],
+      formData: {}
+    };
+    expect(canActionProceed(ACTION, PAGE, Validate.page)).toBeFalsy();
   });
 
 });

--- a/src/components/FormRenderer/helpers/canCYASubmit.js
+++ b/src/components/FormRenderer/helpers/canCYASubmit.js
@@ -1,21 +1,13 @@
-// Local imports
-import Utils from '../../../utils';
-
 /**
  * Assesses whether the CYA screen can submit.
  * Presently, this will validate all of the form pages and, only if all pages are
  * valid will it proceed.
  * @param {Array} pages All of the pages contained within the form.
- * @param {Function} onError A function to call with any validation errors.
+ * @param {Function} pagesValidator A function to validate the page.
  * @returns A boolean where `true` means the CYA can submit and `false` means it cannot.
  */
-const canCYASubmit = (pages, onError) => {
-  const errors = [];
-  pages.forEach(p => {
-    errors.push(...Utils.Validate.page(p));
-  });
-  onError(errors);
-  return errors.length === 0;
+const canCYASubmit = (pages, pagesValidator) => {
+  return pagesValidator(pages).length === 0;
 };
 
 export default canCYASubmit;

--- a/src/components/FormRenderer/helpers/canCYASubmit.test.js
+++ b/src/components/FormRenderer/helpers/canCYASubmit.test.js
@@ -1,109 +1,61 @@
 // Local imports
+import Validate from '../../../utils/Validate';
 import canCYASubmit from './canCYASubmit';
 
-describe('components', () => {
+describe('components.FormRenderer.helpers.canCYASubmit', () => {
 
-  describe('FormRenderer', () => {
+  const ALPHA = { id: 'a', fieldId: 'a', label: 'Alpha', required: true };
+  const CHARLIE = { id: 'c', fieldId: 'c', label: 'Charlie', required: true };
+  const validatePages = (pages) => {
+    return pages.flatMap(page => Validate.page(page));
+  };
 
-    describe('helpers', () => {
+  it('should return true when all pages are valid', () => {
+    const PAGE_1 = {
+      components: [ ALPHA ],
+      formData: { a: 'Bravo' }
+    };
+    const PAGE_2 = {
+      components: [ CHARLIE ],
+      formData: { c: 'Delta' }
+    };
+    expect(canCYASubmit([ PAGE_1, PAGE_2 ], validatePages)).toBeTruthy();
+  });
 
-      describe('canCYASubmit', () => {
+  it('should return false when the first page is invalid', () => {
+    const PAGE_1 = {
+      components: [ ALPHA ],
+      formData: {}
+    };
+    const PAGE_2 = {
+      components: [ CHARLIE ],
+      formData: { c: 'Delta' }
+    };
+    expect(canCYASubmit([PAGE_1, PAGE_2], validatePages)).toBeFalsy();
+  });
 
-        it('should return true when all pages are valid', () => {
-          const PAGE_1 = {
-            components: [
-              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
-            ],
-            formData: {
-              a: 'Bravo'
-            }
-          };
-          const PAGE_2 = {
-            components: [
-              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
-            ],
-            formData: {
-              c: 'Delta'
-            }
-          };
-          expect(canCYASubmit([ PAGE_1, PAGE_2 ], () => {})).toBeTruthy();
-        });
+  it('should return false when the second page is invalid', () => {
+    const PAGE_1 = {
+      components: [ ALPHA ],
+      formData: { a: 'Bravo' }
+    };
+    const PAGE_2 = {
+      components: [ CHARLIE ],
+      formData: {}
+    };
+    expect(canCYASubmit([PAGE_1, PAGE_2], validatePages)).toBeFalsy();
+  });
 
-        it('should return false when the first page is invalid and should have called the onErrors method appropriately', () => {
-          const PAGE_1 = {
-            components: [
-              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
-            ],
-            formData: {}
-          };
-          const PAGE_2 = {
-            components: [
-              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
-            ],
-            formData: {
-              c: 'Delta'
-            }
-          };
-          const ERRORS = [];
-          const ON_ERROR = (errors) => {
-            ERRORS.push(...errors);
-          };
-          expect(canCYASubmit([PAGE_1, PAGE_2], ON_ERROR)).toBeFalsy();
-          expect(ERRORS.length).toEqual(1);
-          expect(ERRORS[0]).toEqual({ id: 'a', error: 'Alpha is required' });
-        });
-
-        it('should return false when the second page is invalid and should have called the onErrors method appropriately', () => {
-          const PAGE_1 = {
-            components: [
-              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
-            ],
-            formData: {
-              a: 'Bravo'
-            }
-          };
-          const PAGE_2 = {
-            components: [
-              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
-            ],
-            formData: {}
-          };
-          const ERRORS = [];
-          const ON_ERROR = (errors) => {
-            ERRORS.push(...errors);
-          };
-          expect(canCYASubmit([PAGE_1, PAGE_2], ON_ERROR)).toBeFalsy();
-          expect(ERRORS.length).toEqual(1);
-          expect(ERRORS[0]).toEqual({ id: 'c', error: 'Charlie is required' });
-        });
-
-        it('should return false when the both pages are invalid and should have called the onErrors method appropriately', () => {
-          const PAGE_1 = {
-            components: [
-              { id: 'a', fieldId: 'a', label: 'Alpha', required: true }
-            ],
-            formData: {}
-          };
-          const PAGE_2 = {
-            components: [
-              { id: 'c', fieldId: 'c', label: 'Charlie', required: true }
-            ],
-            formData: {}
-          };
-          const ERRORS = [];
-          const ON_ERROR = (errors) => {
-            ERRORS.push(...errors);
-          };
-          expect(canCYASubmit([PAGE_1, PAGE_2], ON_ERROR)).toBeFalsy();
-          expect(ERRORS.length).toEqual(2);
-          expect(ERRORS[0]).toEqual({ id: 'a', error: 'Alpha is required' });
-          expect(ERRORS[1]).toEqual({ id: 'c', error: 'Charlie is required' });
-        });
-
-      });
-
-    });
-
+  it('should return false when the both pages are invalid', () => {
+    const PAGE_1 = {
+      components: [ ALPHA ],
+      formData: {}
+    };
+    const PAGE_2 = {
+      components: [ CHARLIE ],
+      formData: {}
+    };
+    expect(canCYASubmit([PAGE_1, PAGE_2], validatePages)).toBeFalsy();
   });
 
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // Local imports
-import FormRenderer from './components/FormRenderer';
-import SummaryList from './components/SummaryList';
+import { FormRenderer, SummaryList } from './components';
+import { ValidationContextProvider } from './context';
 import { addHook, removeHook, resetHooks } from './hooks/useHooks';
 import { FormTypes, HubFormats } from './models';
 import Utils from './utils';
@@ -17,7 +17,8 @@ export {
   SummaryList,
   FormTypes,
   HubFormats,
-  Utils
+  Utils,
+  ValidationContextProvider
 };
 
 export default FormRenderer;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,9 +1,14 @@
 import { render } from '@testing-library/react';
+import { render as domRender } from 'react-dom';
 import { ValidationContextProvider } from './context';
 
 export const renderWithValidation = (ui, options) => render(
   <ValidationContextProvider>{ui}</ValidationContextProvider>
 , options);
+
+export const renderDomWithValidation = (ui, container, callback) => domRender(
+  <ValidationContextProvider>{ui}</ValidationContextProvider>
+, container, callback);
 
 export const expectObjectLike = (received, expected) => {
   Object.keys(expected).forEach(key => {


### PR DESCRIPTION
### Description
The `FormRenderer` component has been refactored to wrap an `InternalFormRenderer` component inside of a `ValidationContextProvider`, which handles errors and validation across the form now.

This has removed the need for holding onto error states in the form JSON, which made it much harder to track and manage - errors and validation are now accessed within components via a `useValidation()` hook.

https://support.cop.homeoffice.gov.uk/browse/COP-10873

### To test
Covered by accompanying unit tests, which have all been updated appropriately.