### PR TITLE
COP-10947: Add hooks context

### DIFF
--- a/src/components/CheckYourAnswers/Answer.test.js
+++ b/src/components/CheckYourAnswers/Answer.test.js
@@ -1,7 +1,7 @@
 // Global imports
-import { render } from '@testing-library/react';
 import { DEFAULT_CLASS as DEFAULT_READONLY_CLASS } from '@ukhomeoffice/cop-react-components/dist/Readonly';
 import React from 'react';
+import { renderWithValidation } from '../../setupTests';
 
 // Local imports
 import Answer from './Answer';
@@ -13,7 +13,7 @@ describe('components', () => {
     it('should handle a null value', async () => {
       const VALUE = null;
       const COMPONENT = null;
-      const { container } = render(
+      const { container } = renderWithValidation(
         <Answer value={VALUE} component={COMPONENT} />
       );
       expect(container.childNodes.length).toEqual(1);
@@ -23,7 +23,7 @@ describe('components', () => {
     it('should handle a null component', async () => {
       const VALUE = 'Alpha';
       const COMPONENT = null;
-      const { container } = render(
+      const { container } = renderWithValidation(
         <Answer value={VALUE} component={COMPONENT} />
       );
       expect(container.textContent).toEqual(VALUE);
@@ -32,7 +32,7 @@ describe('components', () => {
     it('should handle a component', async () => {
       const VALUE = 'Bravo';
       const COMPONENT = { id: 'alpha', fieldId: 'alpha', type: 'text', label: 'Alpha' };
-      const { container } = render(
+      const { container } = renderWithValidation(
         <Answer value={VALUE} component={COMPONENT} />
       );
       const answer = container.childNodes[0];

--- a/src/components/FormComponent/FormComponent.test.js
+++ b/src/components/FormComponent/FormComponent.test.js
@@ -2,17 +2,12 @@
 import React from 'react';
 
 // Local imports
-import { addHook, resetHooks } from '../../hooks/useHooks';
 import { renderWithValidation } from '../../setupTests';
 import FormComponent from './FormComponent';
 
 describe('components', () => {
 
   describe('FormComponent', () => {
-
-    beforeEach(() => {
-      resetHooks();
-    });
 
     it('should render a text component appropriately', async () => {
       const ID = 'component';
@@ -72,28 +67,32 @@ describe('components', () => {
     });
 
     it('should render an overridden html component appropriately', async () => {
-      addHook('onGetComponent', (config, wrap) => {
-        return <div>{`${config.type} | ${config.tagName} | ${config.content} | ${wrap}`}</div>
-      });
+      const hooks = {
+        onGetComponent: (config, wrap) => {
+          return <div>{`${config.type} | ${config.tagName} | ${config.content} | ${wrap}`}</div>
+        }
+      };
       const ID = 'component';
       const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
       const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} />
-      );
+      , { hooks });
       const div = container.childNodes[0];
       expect(div.tagName).toEqual('DIV');
       expect(div.textContent).toEqual(`${COMPONENT.type} | ${COMPONENT.tagName} | ${COMPONENT.content} | true`);
     });
 
     it('should render the correct html component when the override returns null', async () => {
-      addHook('onGetComponent', () => {
-        return null;
-      });
+      const hooks = {
+        onGetComponent: () => {
+          return null;
+        }
+      };
       const ID = 'component';
       const COMPONENT = { type: 'html', tagName: 'p', content: 'HTML content' };
       const { container } = renderWithValidation(
         <FormComponent data-testid={ID} component={COMPONENT} />
-      );
+      , { hooks });
       const p = container.childNodes[0];
       expect(p.tagName).toEqual('P');
       expect(p.textContent).toEqual(COMPONENT.content);

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 // Local imports
-import { ValidationContextProvider } from '../../context';
+import { HooksContextProvider, ValidationContextProvider } from '../../context';
 import { useHooks, useValidation } from '../../hooks';
 import { EventTypes, FormPages, FormTypes, HubFormats, PageAction, TaskStates } from '../../models';
 import Utils from '../../utils';
@@ -34,24 +34,25 @@ const FormRenderer = ({
   noChangeAction,
 }) => {
   return (
-    <ValidationContextProvider>
-      <InternalFormRenderer
-        title={title}
-        type={type}
-        components={components}
-        pages={pages}
-        hub={hub}
-        cya={cya}
-        data={data}
-        hooks={hooks}
-        classBlock={classBlock}
-        classModifiers={classModifiers}
-        className={className}
-        hide_title={hide_title}
-        summaryListClassModifiers={summaryListClassModifiers}
-        noChangeAction={noChangeAction}
-      />
-    </ValidationContextProvider>
+    <HooksContextProvider overrides={hooks}>
+      <ValidationContextProvider>
+        <InternalFormRenderer
+          title={title}
+          type={type}
+          components={components}
+          pages={pages}
+          hub={hub}
+          cya={cya}
+          data={data}
+          classBlock={classBlock}
+          classModifiers={classModifiers}
+          className={className}
+          hide_title={hide_title}
+          summaryListClassModifiers={summaryListClassModifiers}
+          noChangeAction={noChangeAction}
+        />
+      </ValidationContextProvider>
+    </HooksContextProvider>
   );
 };
 
@@ -64,7 +65,6 @@ const InternalFormRenderer = ({
   hub: _hub,
   cya,
   data: _data,
-  hooks: _hooks,
   classBlock,
   classModifiers,
   className,
@@ -83,14 +83,7 @@ const InternalFormRenderer = ({
   const [hubDetails, setHubDetails] = useState({});
 
   // Set up hooks.
-  const { hooks, addHook } = useHooks();
-  useEffect(() => {
-    if (_hooks) {
-      Object.keys(_hooks).forEach(key => {
-        addHook(key, _hooks[key]);
-      });
-    }
-  }, [_hooks, addHook]);
+  const { hooks } = useHooks();
 
   // Set up the useValidation hook.
   const { addErrors, clearErrors, validate } = useValidation();
@@ -327,12 +320,7 @@ FormRenderer.propTypes = InternalFormRenderer.propTypes = {
   hub: PropTypes.object,
   cya: PropTypes.object,
   data: PropTypes.object,
-  hooks: PropTypes.shape({
-    onFormLoad: PropTypes.func,
-    onPageChange: PropTypes.func,
-    onRequest: PropTypes.func,
-    onSubmit: PropTypes.func
-  }),
+  hooks: PropTypes.object,
   classBlock: PropTypes.string,
   classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string,

--- a/src/context/HooksContext/HooksContext.jsx
+++ b/src/context/HooksContext/HooksContext.jsx
@@ -1,0 +1,54 @@
+// Global imports
+import { createContext, useState } from 'react';
+
+const DEFAULT_HOOKS = {
+  onFormComplete: () => {},
+  onFormLoad: () => {},
+  onGetComponent: (config, wrap) => null,
+  onPageChange: (pageId) => pageId,
+  onRequest: (req) => req,
+  onSubmit: (type, payload, onSuccess, onError) => {
+    if (typeof onSuccess === 'function') onSuccess();
+  }
+};
+
+export const ALLOWED_HOOKS = Object.keys(DEFAULT_HOOKS);
+
+export const HooksContext = createContext();
+
+const HooksContextProvider = ({ overrides, children }) => {
+  const [hooks, setHooks] = useState({
+    onFormComplete: overrides?.onFormComplete || DEFAULT_HOOKS.onFormComplete,
+    onFormLoad: overrides?.onFormLoad ||  DEFAULT_HOOKS.onFormLoad,
+    onGetComponent: overrides?.onGetComponent ||  DEFAULT_HOOKS.onGetComponent,
+    onPageChange: overrides?.onPageChange ||  DEFAULT_HOOKS.onPageChange,
+    onRequest: overrides?.onRequest ||  DEFAULT_HOOKS.onRequest,
+    onSubmit: overrides?.onSubmit ||  DEFAULT_HOOKS.onSubmit
+  });
+
+  const addHook = (name, hook) => {
+    if (ALLOWED_HOOKS.includes(name)) {
+      setHooks(prev => ({
+        ...prev,
+        [name]: hook || DEFAULT_HOOKS[name] // Don't allow it to be undefined.
+      }));
+    }
+  };
+  
+  const removeHook = (name) => {
+    if (ALLOWED_HOOKS.includes(name)) {
+      setHooks(prev => ({
+        ...prev,
+        [name]: DEFAULT_HOOKS[name]
+      }));
+    }
+  };
+
+  return (
+    <HooksContext.Provider value={{ hooks, addHook, removeHook }}>
+      {children}
+    </HooksContext.Provider>
+  );
+};
+
+export default HooksContextProvider;

--- a/src/context/HooksContext/HooksContext.test.js
+++ b/src/context/HooksContext/HooksContext.test.js
@@ -1,0 +1,40 @@
+// Global imports
+import { render } from '@testing-library/react';
+import React from 'react';
+
+// Local imports
+import { useHooks } from '../../hooks';
+import HooksContextProvider, { ALLOWED_HOOKS } from './HooksContext';
+
+const TestComponent = () => {
+  const { hooks, addHook, removeHook } = useHooks();
+  return (
+    <>
+      {typeof (addHook) === 'function' && <span>addHook is a function</span>}
+      {typeof (removeHook) === 'function' && <span>removeHook is a function</span>}
+      {
+        Object.keys(hooks).map(key => {
+          return typeof hooks[key] === 'function' && <span key={key}>{key} is a function</span>
+        })
+      }
+    </>
+  );
+};
+
+describe('context.ValidationContext', () => {
+
+  it('should appropriately set up the context', async () => {
+    const { container } = render(
+      <HooksContextProvider>
+        <TestComponent />
+      </HooksContextProvider>
+    );
+    expect(container.childNodes.length).toEqual(2 + ALLOWED_HOOKS.length);
+    expect(container.textContent).toContain('addHook is a function');
+    expect(container.textContent).toContain('removeHook is a function');
+    ALLOWED_HOOKS.forEach(hook => {
+      expect(container.textContent).toContain(`${hook} is a function`);
+    })
+  });
+
+});

--- a/src/context/HooksContext/index.js
+++ b/src/context/HooksContext/index.js
@@ -1,0 +1,4 @@
+import HooksContextProvider, { HooksContext } from './HooksContext';
+
+export { HooksContext };
+export default HooksContextProvider;

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,5 +1,7 @@
+import HooksContextProvider from './HooksContext';
 import ValidationContextProvider from './ValidationContext';
 
 export {
+  HooksContextProvider,
   ValidationContextProvider
 };

--- a/src/hooks/useAxios.test.js
+++ b/src/hooks/useAxios.test.js
@@ -1,11 +1,10 @@
 // Global imports
-import { renderHook } from '@testing-library/react-hooks';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 // Local imports
+import { renderHookWithProvider } from '../setupTests';
 import useAxios from './useAxios';
-import { addHook } from './useHooks';
 
 describe('hooks', () => {
 
@@ -14,7 +13,7 @@ describe('hooks', () => {
 
     it('can perform a API call', async () => {
       mockAxios.onGet('/api/data').reply(200, [{ id: 'test' }]);
-      const axiosInstance = renderHook(() => useAxios('token'));
+      const axiosInstance = renderHookWithProvider(() => useAxios('token'));
 
       const result = await axiosInstance.result.current.get('/api/data');
       expect(result.status).toBe(200);
@@ -23,7 +22,7 @@ describe('hooks', () => {
 
     it('can log error to server if api call fails', async () => {
       mockAxios.onGet('/api/data').reply(500, {});
-      const axiosInstance = renderHook(() => useAxios('token'));
+      const axiosInstance = renderHookWithProvider(() => useAxios('token'));
 
       let error = undefined;
       try {
@@ -37,12 +36,14 @@ describe('hooks', () => {
 
     it('calls the onRequest hook when specified', async () => {
       let onRequestHookCalled = false;
-      addHook('onRequest', (req) => {
-        onRequestHookCalled = true;
-        return req;
-      });
+      const hooks = {
+        onRequest: (req) => {
+          onRequestHookCalled = true;
+          return req;
+        }
+      };
       mockAxios.onGet('/api/data').reply(200, [{ id: 'test' }]);
-      const axiosInstance = renderHook(() => useAxios('token'));
+      const axiosInstance = renderHookWithProvider(() => useAxios('token'), { hooks });
 
       expect(onRequestHookCalled).toBeFalsy();
       await axiosInstance.result.current.get('/api/data');

--- a/src/hooks/useGetRequest.test.js
+++ b/src/hooks/useGetRequest.test.js
@@ -2,8 +2,9 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import { unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
+import { renderDomWithValidation } from '../setupTests';
 
 // Local imports
 import sleep from '../utils/sleep.test';
@@ -57,7 +58,7 @@ describe('hooks', () => {
       const URL = '/api/data';
       mockAxios.onGet(URL).reply(200, { data: ABC });
       act(() => {
-        render(<TestComponent url={URL} />, container);
+        renderDomWithValidation(<TestComponent url={URL} />, container);
       });
       expect(container.textContent).toEqual(STATUS_FETCHING);
 
@@ -76,7 +77,7 @@ describe('hooks', () => {
       const URL = '/api/error';
       mockAxios.onGet(URL).reply(500, {});
       act(() => {
-        render(<TestComponent url={URL} />, container);
+        renderDomWithValidation(<TestComponent url={URL} />, container);
       });
       expect(container.textContent).toEqual(STATUS_FETCHING);
 
@@ -93,7 +94,7 @@ describe('hooks', () => {
         }
       };
       act(() => {
-        render(<TestComponent url={URL} notifyOfCancel={notifyOfCancel} />, container);
+        renderDomWithValidation(<TestComponent url={URL} notifyOfCancel={notifyOfCancel} />, container);
       });
       expect(container.textContent).toEqual(STATUS_FETCHING);
 

--- a/src/hooks/useHooks.js
+++ b/src/hooks/useHooks.js
@@ -1,50 +1,11 @@
-export const ALLOWED_HOOKS = [
-  'onFormComplete',
-  'onFormLoad',
-  'onGetComponent',
-  'onPageChange',
-  'onRequest',
-  'onSubmit'
-];
+// Global imports
+import { useContext } from 'react';
 
-const DEFAULT_HOOKS = {
-  onFormComplete: () => {},
-  onFormLoad: () => {},
-  onGetComponent: (config, wrap) => null,
-  onPageChange: (pageId) => pageId,
-  onRequest: (req) => req,
-  onSubmit: (type, payload, onSuccess, onError) => {
-    if (typeof onSuccess === 'function') onSuccess();
-  }
-};
-
-const hooks = {
-  onFormComplete: DEFAULT_HOOKS.onFormComplete,
-  onFormLoad: DEFAULT_HOOKS.onFormLoad,
-  onGetComponent: DEFAULT_HOOKS.onGetComponent,
-  onPageChange: DEFAULT_HOOKS.onPageChange,
-  onRequest: DEFAULT_HOOKS.onRequest,
-  onSubmit: DEFAULT_HOOKS.onSubmit
-};
-
-export const addHook = (name, hook) => {
-  if (ALLOWED_HOOKS.includes(name)) {
-    hooks[name] = hook || DEFAULT_HOOKS[name]; // Don't allow it to be undefined.
-  }
-};
-
-export const removeHook = (name) => {
-  if (ALLOWED_HOOKS.includes(name)) {
-    hooks[name] = DEFAULT_HOOKS[name];
-  }
-};
-
-export const resetHooks = () => {
-  Object.keys(hooks).forEach(removeHook);
-};
+// Local imports
+import { HooksContext } from '../context/HooksContext';
 
 const useHooks = () => {
-  return { hooks, addHook, removeHook, resetHooks };
+  return useContext(HooksContext);
 };
 
 export default useHooks;

--- a/src/hooks/useHooks.test.js
+++ b/src/hooks/useHooks.test.js
@@ -1,17 +1,12 @@
-// Global imports
-import { renderHook } from '@testing-library/react-hooks';
-
 // Local imports
+import { ALLOWED_HOOKS } from '../context/HooksContext/HooksContext';
 import { PageAction } from '../models';
-import useHooks, { ALLOWED_HOOKS, resetHooks } from './useHooks';
+import { renderHookWithProvider } from '../setupTests';
+import useHooks from './useHooks';
 
 describe('hooks', () => {
 
   describe('useHooks', () => {
-
-    afterEach(async () => {
-      resetHooks();
-    });
 
     const checkResult = (result) => {
       expect(result).toBeDefined();
@@ -22,7 +17,7 @@ describe('hooks', () => {
     };
 
     it('should have default hooks in place', async () => {
-      const { result } = renderHook(() => useHooks());
+      const { result } = renderHookWithProvider(() => useHooks());
       const { hooks, addHook } = checkResult(result);
       expect(hooks).toBeDefined();
       ALLOWED_HOOKS.forEach(hook => {
@@ -34,50 +29,50 @@ describe('hooks', () => {
     ALLOWED_HOOKS.forEach(hook => {
 
       it(`should allow ${hook} to be overridden`, async () => {
-        const { result } = renderHook(() => useHooks());
-        const { hooks, addHook } = checkResult(result);
+        const { result } = renderHookWithProvider(() => useHooks());
+        const { addHook } = checkResult(result);
         let FN_CALLS = 0;
         const NEW_FN = (req) => {
           FN_CALLS++;
           return req;
         }
-        expect(hooks[hook]).not.toEqual(NEW_FN);
+        expect(result.current.hooks[hook]).not.toEqual(NEW_FN);
         expect(FN_CALLS).toEqual(0);
-        hooks[hook]({});
+        result.current.hooks[hook]({});
         expect(FN_CALLS).toEqual(0);
         addHook(hook, NEW_FN);
-        expect(hooks[hook]).toEqual(NEW_FN);
+        expect(result.current.hooks[hook]).toEqual(NEW_FN);
         expect(FN_CALLS).toEqual(0);
-        hooks[hook]({});
+        result.current.hooks[hook]({});
         expect(FN_CALLS).toEqual(1);
       });
 
       it(`should revert ${hook} to the default pass-through handler when clearing it`, async () => {
-        const { result } = renderHook(() => useHooks());
-        const { hooks, addHook } = checkResult(result);
+        const { result } = renderHookWithProvider(() => useHooks());
+        const { addHook, removeHook } = checkResult(result);
         let FN_CALLS = 0;
         const NEW_FN = (req) => {
           FN_CALLS++;
           return req;
         }
         expect(FN_CALLS).toEqual(0);
-        expect(hooks[hook]).not.toEqual(NEW_FN);
+        expect(result.current.hooks[hook]).not.toEqual(NEW_FN);
         addHook(hook, NEW_FN);
-        expect(hooks[hook]).toEqual(NEW_FN);
+        expect(result.current.hooks[hook]).toEqual(NEW_FN);
         expect(FN_CALLS).toEqual(0);
-        hooks[hook]({});
+        result.current.hooks[hook]({});
         expect(FN_CALLS).toEqual(1);
-        addHook(hook, undefined);
-        hooks[hook]({});
+        removeHook(hook);
+        result.current.hooks[hook]({});
         expect(FN_CALLS).toEqual(1); // Didn't increase
-        expect(typeof hooks[hook]).toEqual('function');
-        expect(hooks[hook]).not.toEqual(NEW_FN);
+        expect(typeof result.current.hooks[hook]).toEqual('function');
+        expect(result.current.hooks[hook]).not.toEqual(NEW_FN);
       });
 
     });
 
     it('should call onSuccess function of onSubmit hook by default', async () => {
-      const { result } = renderHook(() => useHooks());
+      const { result } = renderHookWithProvider(() => useHooks());
       const { hooks } = checkResult(result);
       let onSuccessCalled = false;
       let onErrorCalled = false;
@@ -93,14 +88,14 @@ describe('hooks', () => {
     });
 
     it('should not allow an unknown hook to be added', async () => {
-      const { result } = renderHook(() => useHooks());
+      const { result } = renderHookWithProvider(() => useHooks());
       const { hooks, addHook } = checkResult(result);
       addHook('onUnknown', () => {});
       expect(hooks.onUnknown).not.toBeDefined();
     });
 
     it('should do nothing if removing an unknown hook', async () => {
-      const { result } = renderHook(() => useHooks());
+      const { result } = renderHookWithProvider(() => useHooks());
       const { hooks, removeHook } = checkResult(result);
       // Add to the hooks object, which is essentially meaningless in real use as there is nothing
       // in any of the logic to call it.

--- a/src/hooks/useRefData.test.js
+++ b/src/hooks/useRefData.test.js
@@ -2,8 +2,9 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import { unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
+import { renderDomWithValidation } from '../setupTests';
 
 // Local imports
 import sleep from '../utils/sleep.test';
@@ -49,7 +50,7 @@ describe('hooks', () => {
     it('can handle a component with no data url', async () => {
       const COMPONENT = { id: 'component' };
       act(() => {
-        render(<TestComponent component={COMPONENT} />, container);
+        renderDomWithValidation(<TestComponent component={COMPONENT} />, container);
       });
       expect(container.textContent).toEqual(STATUS_COMPLETE);
     });
@@ -62,7 +63,7 @@ describe('hooks', () => {
       };
       mockAxios.onGet(URL).reply(200, { data: ABC });
       act(() => {
-        render(<TestComponent component={COMPONENT} />, container);
+        renderDomWithValidation(<TestComponent component={COMPONENT} />, container);
       });
       expect(container.textContent).toEqual(STATUS_LOADING);
 
@@ -80,7 +81,7 @@ describe('hooks', () => {
     it('can handle a component with no data url but data options instead', async () => {
       const COMPONENT = { id: 'component', data: { options: ABC } };
       act(() => {
-        render(<TestComponent component={COMPONENT} />, container);
+        renderDomWithValidation(<TestComponent component={COMPONENT} />, container);
       });
 
       expect(container.childNodes.length).toEqual(1);
@@ -101,7 +102,7 @@ describe('hooks', () => {
       };
       mockAxios.onGet(URL).reply(500, {});
       act(() => {
-        render(<TestComponent component={COMPONENT} />, container);
+        renderDomWithValidation(<TestComponent component={COMPONENT} />, container);
       });
       expect(container.textContent).toEqual(STATUS_LOADING);
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,14 +1,26 @@
 import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { render as domRender } from 'react-dom';
-import { ValidationContextProvider } from './context';
+import { HooksContextProvider, ValidationContextProvider } from './context';
 
 export const renderWithValidation = (ui, options) => render(
-  <ValidationContextProvider>{ui}</ValidationContextProvider>
+  <HooksContextProvider overrides={options?.hooks}>
+    <ValidationContextProvider key="vcp">{ui}</ValidationContextProvider>
+  </HooksContextProvider>
 , options);
 
-export const renderDomWithValidation = (ui, container, callback) => domRender(
-  <ValidationContextProvider>{ui}</ValidationContextProvider>
-, container, callback);
+export const renderDomWithValidation = (ui, container, options) => domRender(
+  <HooksContextProvider overrides={options?.hooks}>
+    <ValidationContextProvider key="vcp">{ui}</ValidationContextProvider>
+  </HooksContextProvider>
+, container);
+
+export const renderHookWithProvider = (hook, options) => {
+  const wrapper = ({children}) => (
+    <HooksContextProvider overrides={options?.hooks}>{children}</HooksContextProvider>
+  )
+  return renderHook(() => hook(), { wrapper } );
+};
 
 export const expectObjectLike = (received, expected) => {
   Object.keys(expected).forEach(key => {

--- a/src/utils/CheckYourAnswers/getCYARowForGroup.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowForGroup.test.js
@@ -1,7 +1,5 @@
-// Global imports
-import {render } from '@testing-library/react';
-
-//local imports 
+// Local imports 
+import { renderWithValidation } from '../../setupTests';
 import getCYARowForGroup from './getCYARowForGroup';
 import getCYARow from './getCYARow';
 
@@ -45,7 +43,9 @@ describe('utils', () => {
         const rows = PAGE.components.map(component => {
           return getCYARow(PAGE, component, ON_ACTION);
         });
-        const { container } = render(getCYARowForGroup(PAGE, PAGE.groups[0], rows, ON_ACTION).row.value);
+        const { container } = renderWithValidation(
+          getCYARowForGroup(PAGE, PAGE.groups[0], rows, ON_ACTION).row.value
+        );
         expect(container.childNodes.length).toEqual(4);
         const addressValues = container.childNodes;
         expect(addressValues[0].childNodes[0].textContent).toEqual('10 Downing Street')

--- a/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
+++ b/src/utils/CheckYourAnswers/getCYARowsForPage.test.js
@@ -1,8 +1,5 @@
-// Global imports
-import { render } from '@testing-library/react';
-
 // Local imports
-import { expectObjectLike } from '../../setupTests';
+import { expectObjectLike, renderWithValidation } from '../../setupTests';
 import { ComponentTypes } from '../../models';
 import getCYARowsForPage from './getCYARowsForPage';
 
@@ -149,7 +146,7 @@ describe('utils', () => {
           },
         };
         const ON_ACTION = () => {};
-        const { container } = render(getCYARowsForPage(PAGE, ON_ACTION).map(row => row.value));
+        const { container } = renderWithValidation(getCYARowsForPage(PAGE, ON_ACTION).map(row => row.value));
         expect(container.childNodes.length).toEqual(4);
         const addressValues = container.childNodes;
         expect(addressValues[0].childNodes[0].textContent).toEqual('10 Downing Street')


### PR DESCRIPTION
### Description
Added a `HooksContext` and `HooksContextProvider`, which will replace the functionality previously implemented directly by `useHooks`.

https://support.cop.homeoffice.gov.uk/browse/COP-10947

### To test
Accompanying unit tests will be included in the next PR - it's not in this one directly simply because it leverages the refactored `useHooks` hook... but including that in this PR means all of the _other_ components and tests that need `useHooks` will also need to be included, and then it's a big PR.