### PR TITLE
Import React in ValidationContext.jsx

### DIFF
--- a/src/context/ValidationContext/ValidationContext.jsx
+++ b/src/context/ValidationContext/ValidationContext.jsx
@@ -1,5 +1,5 @@
 // Global imports
-import { createContext, useState } from 'react';
+import React, { createContext, useState } from 'react';
 
 // Local imports
 import Utils from '../../utils';


### PR DESCRIPTION
While running tests for cop-ui there was an error reporting that React was not defined and a stack trace ending in the ValidationContext jsx file in the renderer.  The fix was to import React from react within that file.