### PR TITLE
Implement regex validation for components.

### DIFF
--- a/src/utils/Validate/index.js
+++ b/src/utils/Validate/index.js
@@ -3,6 +3,7 @@ import validateComponent from './validateComponent';
 import validateDate from './validateDate';
 import validateEmail from './validateEmail';
 import validatePage from './validatePage';
+import validateRegex from './validateRegex';
 import validateRequired from './validateRequired';
 import validateTime from './validateTime';
 
@@ -11,6 +12,7 @@ const Validate = {
   email: validateEmail,
   date: validateDate,
   page: validatePage,
+  regex: validateRegex,
   required: validateRequired,
   time: validateTime
 };

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -6,6 +6,7 @@ import validateCollection from './validateCollection';
 import validateContainer from './validateContainer';
 import validateDate from './validateDate';
 import validateEmail from './validateEmail';
+import validateRegex from './validateRegex';
 import validateRequired from './validateRequired';
 import validateTime from './validateTime';
 
@@ -60,6 +61,9 @@ const validateComponent = (component, formData) => {
         break;
       default:
         break;
+    }
+    if (!error && component.pattern) {
+      error = validateRegex(value, component.label, component.pattern, component.custom_errors);
     }
     if (!error && component.additionalValidation) {
       error = runAdditionalComponentValidation(component, value);

--- a/src/utils/Validate/validateRegex.js
+++ b/src/utils/Validate/validateRegex.js
@@ -7,11 +7,12 @@
  * @param {string} label The label to use in the default error message.
  * @param {string} pattern The regex pattern to validate against.
  * @param {array} customErrors The array of custom errors for the component.
- * @returns An error if the email address is invalid.
+ * @returns An error if the value doesn't match the regex pattern.
  */
-const validateRegex = (value, label='', pattern, customErrors) => {
-  if (!value)
+const validateRegex = (value, label = '', pattern, customErrors) => {
+  if (!value) {
     return undefined;
+  }
   if (typeof value === 'string') {
     const regex = new RegExp(pattern);
     if (regex.test(value)) {
@@ -21,13 +22,14 @@ const validateRegex = (value, label='', pattern, customErrors) => {
       const result = customErrors.filter((error) => {
         return error.type === 'pattern';
       });
-      if (result && result.length > 0 && result[0].message) {
+      if (result?.[0]?.message) {
         return result[0].message;
       }
     }
   }
-  if (label === '')
+  if (label === '') {
     return 'Component failed regex validation';
+  }
   return `${label} failed regex validation`;
 };
 

--- a/src/utils/Validate/validateRegex.js
+++ b/src/utils/Validate/validateRegex.js
@@ -1,0 +1,34 @@
+/**
+ * Validates an components value against a given regex pattern.
+ * 
+ * An empty string for value is considered valid as not all components
+ * with pattern validation have to be required. 
+ * @param {*} value The value to validate.
+ * @param {string} label The label to use in the default error message.
+ * @param {string} pattern The regex pattern to validate against.
+ * @param {array} customErrors The array of custom errors for the component.
+ * @returns An error if the email address is invalid.
+ */
+const validateRegex = (value, label='', pattern, customErrors) => {
+  if (!value)
+    return undefined;
+  if (typeof value === 'string') {
+    const regex = new RegExp(pattern);
+    if (regex.test(value)) {
+      return undefined;
+    }
+    if (Array.isArray(customErrors)) {
+      const result = customErrors.filter((error) => {
+        return error.type === 'pattern';
+      });
+      if (result && result.length > 0 && result[0].message) {
+        return result[0].message;
+      }
+    }
+  }
+  if (label === '')
+    return 'Component failed regex validation';
+  return `${label} failed regex validation`;
+};
+
+export default validateRegex;

--- a/src/utils/Validate/validateRegex.test.js
+++ b/src/utils/Validate/validateRegex.test.js
@@ -5,7 +5,7 @@ describe('utils', () => {
 
   describe('Validate', () => {
 
-    describe('', () => {
+    describe('regex', () => {
       const GOOD_VALUE = 'hello';
       const BAD_VALUE = 'h3llo';
       const LABEL = 'Component';

--- a/src/utils/Validate/validateRegex.test.js
+++ b/src/utils/Validate/validateRegex.test.js
@@ -1,0 +1,47 @@
+// Local imports
+import validateRegex from './validateRegex';
+
+describe('utils', () => {
+
+  describe('Validate', () => {
+
+    describe('', () => {
+      const GOOD_VALUE = 'hello';
+      const BAD_VALUE = 'h3llo';
+      const LABEL = 'Component';
+      const PATTERN = '^[a-z]*$';
+      const CUSTOM_ERRORS = [
+        {
+          "type": "pattern",
+          "message": `Regex validation failed for ${LABEL}` 
+        }
+      ];
+      const DEFAULT_ERROR = [
+        {
+          "type": "pattern"
+        }
+      ];
+
+      // Valid values
+      it('should return no error when the value matches the regex pattern', () => {
+        expect(validateRegex(GOOD_VALUE, LABEL, PATTERN, CUSTOM_ERRORS)).toBeUndefined();
+      });
+      it('should return no error when the value is an empty string', () => {
+        expect(validateRegex('', LABEL, PATTERN, CUSTOM_ERRORS)).toBeUndefined();
+      });
+
+      // Invalid values
+      it('should return a custom error when the value does not match the regex pattern and one is specified', () => {
+        expect(validateRegex(BAD_VALUE, LABEL, PATTERN, CUSTOM_ERRORS)).toEqual(CUSTOM_ERRORS[0].message);
+      });
+      it('should return an error using label when the value does not match the regex pattern and a custom error is not specified', () => {
+        expect(validateRegex(BAD_VALUE, LABEL, PATTERN, DEFAULT_ERROR)).toEqual(`${LABEL} failed regex validation`);
+      });
+      it('should return a default error when the value does not match the regex pattern and both a custom error and label are not specified', () => {
+        expect(validateRegex(BAD_VALUE, '', PATTERN, DEFAULT_ERROR)).toEqual('Component failed regex validation');
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
Added the ability to define regex validation for a component in the form renderer JSON files. Custom errors for when the regex validation failed can also now be defined.

Doing so looks like:
```
...
"type": "text",
"pattern": "^[a-z]*$",
"custom_errors": [
   {
   "type": "pattern",
   "message": "Failed regex validation."
   }
]
...
```