### PR TITLE
COP-10967: Use version 1.7.1 of component library

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.6.0",
+    "@ukhomeoffice/cop-react-components": "1.7.1",
     "axios": "^0.21.1",
     "dayjs": "^1.11.0",
     "govuk-frontend": "^3.13.0",

--- a/src/utils/Component/getComponentTests/getComponent.date.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.date.test.js
@@ -70,22 +70,22 @@ describe('utils.Component.get', () => {
 
     // Add something to the day and make sure it fires.
     fireEvent.change(dayinput, { target: { name: `${FIELD_ID}-day`, value: '5' }});
-    expect(ON_CHANGE_CALLS.length).toEqual(2);
-    expect(ON_CHANGE_CALLS[1]).toMatchObject({
+    expect(ON_CHANGE_CALLS.length).toEqual(1);
+    expect(ON_CHANGE_CALLS[0]).toMatchObject({
       name: FIELD_ID,
       value: '5--'
     });
     // And now the month...
     fireEvent.change(monthinput, { target: { name: `${FIELD_ID}-month`, value: '11' }});
-    expect(ON_CHANGE_CALLS.length).toEqual(3);
-    expect(ON_CHANGE_CALLS[2]).toMatchObject({
+    expect(ON_CHANGE_CALLS.length).toEqual(2);
+    expect(ON_CHANGE_CALLS[1]).toMatchObject({
       name: FIELD_ID,
       value: '5-11-'
     });
     // And finally the year.
     fireEvent.change(yearinput, { target: { name: `${FIELD_ID}-year`, value: '2022' }});
-    expect(ON_CHANGE_CALLS.length).toEqual(4);
-    expect(ON_CHANGE_CALLS[3]).toMatchObject({
+    expect(ON_CHANGE_CALLS.length).toEqual(3);
+    expect(ON_CHANGE_CALLS[2]).toMatchObject({
       name: FIELD_ID,
       value: '5-11-2022'
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.6.0.tgz#154fb4d4d8d2bc8f000cfaa47590a6f4932107f1"
-  integrity sha512-xnP6FGuut3vrHJ54ZpG2PJjVthA/GwE2VvZGIzqQ9cLHRq7SLo1bzQ0rbf2kzD3HCYTKx5ai3vD7hpSQMpGbwA==
+"@ukhomeoffice/cop-react-components@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.7.1.tgz#2c7814ccd12250f220d3f391f61feffb1ff96bad"
+  integrity sha512-3jD9EN+37eY7LdXJhbA9hihym+yo6mQixbVFHM10FA0cB0FlRav3TRMe6A/Ve4+hiedTxQvCPBSR9oHz3ElRNA==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"


### PR DESCRIPTION
### Description
Use version 1.7.1 of component library, which fixes an issue with the `DateInput` component.

https://support.cop.homeoffice.gov.uk/browse/COP-10967

### To test
The following was broken in the COP React Form Renderer:
1. Set up the JSON to have a date field;
2. Set up the initial data to have a valid value for that date field;
3. Switch to the Preview tab and you'll see the value appropriately showing in the date field;
4. Go back to the initial date and change to another valid value for the date field;
5. Switch back to the Preview tab and you'll now see the value in the date field flicking between the old and new values.

This should now be fixed.