### PR TITLE
Feature/eab 579 conditional display of multiple nested fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.6.0",
+    "@ukhomeoffice/cop-react-components": "1.7.3",
     "axios": "^0.21.1",
     "dayjs": "^1.11.0",
     "govuk-frontend": "^3.13.0",

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -120,6 +120,7 @@ const FormRenderer = ({
     // Check to see whether the action is able to proceed, which in
     // in the case of a submission will validate the fields in the page.
     if (helpers.canActionProceed(action, formState.page, onError)) {
+      patch = helpers.cleanHiddenNestedData(patch, formState.page);
       if (action.type === PageAction.TYPES.NAVIGATE) {
         handlers.navigate(action, pageId, onPageChange);
       } else {

--- a/src/components/FormRenderer/helpers/cleanHiddenNestedData.js
+++ b/src/components/FormRenderer/helpers/cleanHiddenNestedData.js
@@ -1,0 +1,28 @@
+const parentComponents = ['radios'];
+
+const cleanHiddenNestedData = (patch, page) => {
+  page.components.forEach((component) => {
+    if (!parentComponents.includes(component.type)) {
+      return;
+    }
+    const idsToDelete = getIdsToDelete(component, patch[component.id]);
+    idsToDelete.forEach((id) => {
+      delete patch[id];
+    });
+  });
+  return patch;
+};
+
+function getIdsToDelete(component, selectedValue) {
+    const idsToDelete = [];
+    component?.data?.options?.forEach((option) => {
+        if (option.value !== selectedValue && option.nested) {
+            option.nested.forEach((nested) => {
+                idsToDelete.push(nested.id);
+            });
+        }
+    });
+    return idsToDelete;
+}
+
+export default cleanHiddenNestedData;

--- a/src/components/FormRenderer/helpers/cleanHiddenNestedData.test.js
+++ b/src/components/FormRenderer/helpers/cleanHiddenNestedData.test.js
@@ -1,0 +1,51 @@
+// Local imports
+import cleanHiddenNestedData from './cleanHiddenNestedData';
+
+describe('components', () => {
+  describe('FormRenderer', () => {
+    describe('helpers', () => {
+      describe('cleanHiddenNestedData', () => {
+        it('remove data corresponding to hidden nested components', () => {
+          const patch = { parent: 'option2', nested1: 'should not be included', nested2: 'should be included' };
+          const page = {
+            id: 'page',
+            name: 'page',
+            title: 'Page',
+            components: [
+              {
+                id: 'parent',
+                fieldId: 'parent',
+                type: 'radios',
+                data: {
+                  options: [
+                    {
+                      value: 'option1',
+                      nested: [
+                        {
+                          id: 'nested1',
+                          fieldId: 'nested1',
+                        },
+                      ],
+                    },
+                    {
+                      value: 'option2',
+                      nested: [
+                        {
+                          id: 'nested2',
+                          fieldId: 'nested2',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          };
+          const updatedPatch = cleanHiddenNestedData(patch, page);
+          expect(updatedPatch['nested1']).toBeFalsy();
+          expect(updatedPatch['nested2']).toBeTruthy();
+        });
+      });
+    });
+  });
+});

--- a/src/components/FormRenderer/helpers/index.js
+++ b/src/components/FormRenderer/helpers/index.js
@@ -1,6 +1,7 @@
 // Local imports
 import canActionProceed from './canActionProceed';
 import canCYASubmit from './canCYASubmit';
+import cleanHiddenNestedData from './cleanHiddenNestedData';
 import getFormState from './getFormState';
 import getNextPageId from './getNextPageId';
 import getPage from './getPage';
@@ -10,6 +11,7 @@ import getUpdatedSectionStates from './getUpdatedSectionStates';
 export const helpers = {
   canActionProceed,
   canCYASubmit,
+  cleanHiddenNestedData,
   getFormState,
   getNextPageId,
   getPage,

--- a/src/utils/CheckYourAnswers/getCYARow.js
+++ b/src/utils/CheckYourAnswers/getCYARow.js
@@ -36,7 +36,9 @@ const setNestedValue = (component, page) => {
   component.data?.options?.forEach((option, index) => {
     //check if option is selected and has nested component
     if (page.formData[component.id] === option.value && option.nested) {
-      component.data.options[index].nested.value = page.formData[option.nested.id];
+      option.nested.forEach((child) => {
+        child.value = page.formData[child.id];
+      })
     }
   });
 }

--- a/src/utils/CheckYourAnswers/getCYARow.test.js
+++ b/src/utils/CheckYourAnswers/getCYARow.test.js
@@ -94,15 +94,17 @@ describe('utils', () => {
             options: [
               {
                 value: SELECTED_VALUE,
-                nested: {
-                  id: NESTED_ID,
-                },
-              }
+                nested: [
+                  {
+                    id: NESTED_ID,
+                  },
+                ],
+              },
             ],
           },
         }; 
         const ROW = getCYARow(PAGE, COMPONENT, () => {});
-        expect(ROW.component.data.options[0].nested.value).toEqual(NESTED_VALUE);
+        expect(ROW.component.data.options[0].nested[0].value).toEqual(NESTED_VALUE);
       });
 
     });

--- a/src/utils/Component/cleanAttributes.js
+++ b/src/utils/Component/cleanAttributes.js
@@ -5,7 +5,6 @@ export const JSON_ONLY_PROPERTIES = [
   'options',
   'additionalValidation',
   'full_path',
-  'shown',
   'formData'
 ];
 

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -78,7 +78,7 @@ const getRadios = (config) => {
     if ( !Array.isArray(option.nested) ){
       return;
     }
-    option.nestedJSX = getNestedComponents(config, option.nested);
+    option.children = getChildrenJsx(config, option.nested);
   });
   const attrs = cleanAttributes(config);
   return <Radios {...attrs} options={options} />;
@@ -132,36 +132,38 @@ const getComponentByType = (config) => {
 };
 
 /**
- * Get nested component with form data
- * @param {*} parentConfig 
- * @param {*} nestedConfig 
+ * Get single child component for a parent
+ * @param {*} parent the parent configuration
+ * @param {*} child the child configuration
  */
-const nestedComponent = (parent, nested) => {
+const getChildJsx = (parent, child) => {
   if (parent.formData) {
-    nested.value = parent?.formData?.[nested.fieldId] ? parent.formData[nested.fieldId] : '';
+    child.value = parent?.formData?.[child.fieldId] ? parent.formData[child.fieldId] : '';
   }
-  if ('readonly' in nested)
-    delete nested.readonly;
-  if(parent.readonly){
-    nested.readonly = parent.readonly;
-    return getComponent(nested, false);
+  if ('readonly' in child) delete child.readonly;
+  if (parent.readonly) {
+    child.readonly = parent.readonly;
+    return <div>{getComponent(child, false)}</div>;
   }
-  return <FormComponent component={nested} value={nested.value} onChange={parent.onChange} key={nested.key}/> 
+  return <FormComponent component={child} value={child.value} onChange={parent.onChange} key={child.key} />;
 };
 
 /**
- * Get nested component with form data
- * @param {*} parentConfig 
- * @param {*} nestedConfig 
+ * Convert chidlrenConfigs into components
+ * @param {*} parentConfig parent component which the childrenConfigs will be under
+ * @param {*} childrenConfigs array of configurations for the child components
  */
-const getNestedComponents = (parentConfig, nestedConfigs) => {
-  return nestedConfigs.map((config, index) => {
-    config.key = index;
-    return nestedComponent(parentConfig, config);
-  });
+const getChildrenJsx = (parentConfig, childrenConfigs) => {
+  return (
+    <>
+      {childrenConfigs.map((config) => {
+        return <React.Fragment key={config.id}>{getChildJsx(parentConfig, config)}</React.Fragment>;
+      })}
+    </>
+  );
 };
 
-export { getNestedComponents };
+export { getChildrenJsx };
 
 /**
  * Get a renderable component, based on a configuration object.

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -73,11 +73,16 @@ const getRadios = (config) => {
   Data.getOptions(config, (val) => {
     options = val;
   });
-  options.forEach((option) => {
-    if (!option.nested){
+  options.forEach((option, index) => {
+    if ( !Array.isArray(option.nested) ){
       return;
     }
-    option.nestedJSX = getNestedComponent(config, option);
+    option.setShown = (val) => {
+      console.log("Option " + option.id + " shown is now " + val);
+      config.options[0].shown = val;  
+      option.shown = val;
+    }
+    option.nestedJSX = getNestedComponents(config, option.nested);
   });
   const attrs = cleanAttributes(config);
   return <Radios {...attrs} options={options} />;
@@ -135,21 +140,32 @@ const getComponentByType = (config) => {
  * @param {*} parentConfig 
  * @param {*} nestedConfig 
  */
-const getNestedComponent = (parentConfig, nestedConfig) => {
-  nestedConfig.nested.onChange = parentConfig.onChange;
-  if (parentConfig.formData) {
-    nestedConfig.nested.value = parentConfig?.formData?.[nestedConfig.nested.fieldId] ? parentConfig.formData[nestedConfig.nested.fieldId] : '';
+const createNestedComponent = (parent, nested) => {
+  nested.onChange = parent.onChange;
+  if (parent.formData) {
+    nested.value = parent?.formData?.[nested.fieldId] ? parent.formData[nested.fieldId] : '';
   }
-  if ('readonly' in nestedConfig.nested)
-    delete nestedConfig.nested.readonly;
-  if(parentConfig.readonly){
-    nestedConfig.nested.readonly = parentConfig.readonly;
-    return getComponent(nestedConfig.nested, false);
+  if ('readonly' in nested)
+    delete nested.readonly;
+  if(parent.readonly){
+    nested.readonly = parent.readonly;
+    return getComponent(nested, false);
   }
-  return getComponent(nestedConfig.nested);
+  return getComponent(nested);
 };
 
-export { getNestedComponent };
+/**
+ * Get nested component with form data
+ * @param {*} parentConfig 
+ * @param {*} nestedConfig 
+ */
+const getNestedComponents = (parentConfig, nestedConfigs) => {
+  return nestedConfigs.map((config) => {
+    return createNestedComponent(parentConfig, config);
+  });
+};
+
+export { getNestedComponents };
 
 /**
  * Get a renderable component, based on a configuration object.

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -19,6 +19,7 @@ import { ComponentTypes } from '../../models';
 import Data from '../Data';
 import cleanAttributes from './cleanAttributes';
 import isEditable from './isEditable';
+import FormComponent from '../../components/FormComponent';
 import wrapInFormGroup from './wrapInFormGroup';
 
 /** 
@@ -73,14 +74,9 @@ const getRadios = (config) => {
   Data.getOptions(config, (val) => {
     options = val;
   });
-  options.forEach((option, index) => {
+  options.forEach((option) => {
     if ( !Array.isArray(option.nested) ){
       return;
-    }
-    option.setShown = (val) => {
-      console.log("Option " + option.id + " shown is now " + val);
-      config.options[0].shown = val;  
-      option.shown = val;
     }
     option.nestedJSX = getNestedComponents(config, option.nested);
   });
@@ -140,8 +136,7 @@ const getComponentByType = (config) => {
  * @param {*} parentConfig 
  * @param {*} nestedConfig 
  */
-const createNestedComponent = (parent, nested) => {
-  nested.onChange = parent.onChange;
+const nestedComponent = (parent, nested) => {
   if (parent.formData) {
     nested.value = parent?.formData?.[nested.fieldId] ? parent.formData[nested.fieldId] : '';
   }
@@ -151,7 +146,7 @@ const createNestedComponent = (parent, nested) => {
     nested.readonly = parent.readonly;
     return getComponent(nested, false);
   }
-  return getComponent(nested);
+  return <FormComponent component={nested} value={nested.value} onChange={parent.onChange} key={nested.key}/> 
 };
 
 /**
@@ -160,8 +155,9 @@ const createNestedComponent = (parent, nested) => {
  * @param {*} nestedConfig 
  */
 const getNestedComponents = (parentConfig, nestedConfigs) => {
-  return nestedConfigs.map((config) => {
-    return createNestedComponent(parentConfig, config);
+  return nestedConfigs.map((config, index) => {
+    config.key = index;
+    return nestedComponent(parentConfig, config);
   });
 };
 

--- a/src/utils/Component/getComponentTests/getComponent.nested.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.nested.test.js
@@ -1,42 +1,70 @@
 // Global imports
 import { render } from '@testing-library/react';
 // Local imports
-import { getNestedComponent } from '../getComponent';
+import { getNestedComponents } from '../getComponent';
 
 describe('utils.Component.get', () => {
-
-  it('should return a component that is nested within another component', async () => {
+  it('should return components that are nested within another component', async () => {
     const ID = 'testId';
     const FIELD_ID = 'fieldId';
     const LABEL = 'Test label';
+    const ID2 = 'testId2';
+    const FIELD_ID2 = 'fieldId2';
+    const LABEL2 = 'Test label 2';
     const VALUE = 'nestedValue';
+    const VALUE2 = '1-2-2022';
     const PARENT_CONFIG = {
-        onChange: () => {},
-        formData: {
-            [FIELD_ID]: VALUE
-        }
+      onChange: () => {},
+      formData: {
+        [FIELD_ID]: VALUE,
+        [FIELD_ID2]: VALUE2,
+      },
     };
-    const NESTED_CONFIG = {
-        nested: {
-            id: ID,
-            fieldId: FIELD_ID,
-            label: LABEL,
-            type: 'text'
-        }
-    };
-    const { container } = render(getNestedComponent(PARENT_CONFIG, NESTED_CONFIG));
+    const NESTED_CONFIG = [
+      {
+        id: ID,
+        fieldId: FIELD_ID,
+        label: LABEL,
+        type: 'text',
+      },
+      {
+        id: ID2,
+        fieldId: FIELD_ID2,
+        label: LABEL2,
+        type: 'date',
+      },
+    ];
+    const { container } = render(getNestedComponents(PARENT_CONFIG, NESTED_CONFIG));
     const child = container.childNodes[0];
+    expect(child.childNodes.length).toEqual(3);
     expect(child.classList).toContain('govuk-form-group');
 
     const label = child.childNodes[0];
     expect(label).toBeDefined();
     expect(label.innerHTML).toContain(LABEL);
 
-    const input = child.childNodes[1];
+    const input = child.childNodes[2];
     expect(input.tagName).toEqual('INPUT');
     expect(input.classList).toContain('govuk-input');
     expect(input.id).toEqual(ID);
     expect(input.value).toEqual(VALUE);
+
+
+    const child2 = container.childNodes[1];
+    expect(child2.childNodes.length).toEqual(3);
+    expect(child2.classList).toContain('govuk-form-group');
+
+    const label2 = child2.childNodes[0];
+    expect(label2).toBeDefined();
+    expect(label2.innerHTML).toContain(LABEL2);
+
+    const input2 = child2.childNodes[2];
+    expect(input2.tagName).toEqual('DIV');
+    expect(input2.classList).toContain('govuk-date-input');
+    expect(input2.id).toEqual(ID2);
+    expect(input2.childNodes[0].childNodes[1].value).toEqual('1');
+    expect(input2.childNodes[1].childNodes[1].value).toEqual('2');
+    expect(input2.childNodes[2].childNodes[1].value).toEqual('2022');
   });
 
   it('should return a read only component that is nested within another readonly component', async () => {
@@ -45,24 +73,23 @@ describe('utils.Component.get', () => {
     const LABEL = 'Test label';
     const VALUE = 'nestedValue';
     const PARENT_CONFIG = {
-        onChange: () => {},
-        formData: {
-            [FIELD_ID]: VALUE
-        },
-        readonly: true
+      onChange: () => {},
+      formData: {
+        [FIELD_ID]: VALUE,
+      },
+      readonly: true,
     };
-    const NESTED_CONFIG = {
-        nested: {
-            id: ID,
-            fieldId: FIELD_ID,
-            label: LABEL,
-            type: 'text',
-            readonly: true
-        }
-    };
-    const { container } = render(getNestedComponent(PARENT_CONFIG, NESTED_CONFIG));
+    const NESTED_CONFIG = [
+      {
+        id: ID,
+        fieldId: FIELD_ID,
+        label: LABEL,
+        type: 'text',
+        readonly: true,
+      },
+    ];
+    const { container } = render(getNestedComponents(PARENT_CONFIG, NESTED_CONFIG));
     const child = container.childNodes[0];
     expect(child.classList).toContain('hods-readonly');
-
   });
 });

--- a/src/utils/Component/getComponentTests/getComponent.nested.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.nested.test.js
@@ -2,6 +2,7 @@
 import { render } from '@testing-library/react';
 // Local imports
 import { getChildrenJsx } from '../getComponent';
+import { renderWithValidation } from '../../../setupTests';
 
 describe('utils.Component.get', () => {
   it('should return components that are nested within another component', async () => {
@@ -34,7 +35,7 @@ describe('utils.Component.get', () => {
         type: 'date',
       },
     ];
-    const { container } = render(getChildrenJsx(PARENT_CONFIG, NESTED_CONFIG));
+    const { container } = renderWithValidation(getChildrenJsx(PARENT_CONFIG, NESTED_CONFIG));
     const child = container.childNodes[0];
     expect(child.childNodes.length).toEqual(3);
     expect(child.classList).toContain('govuk-form-group');

--- a/src/utils/Component/getComponentTests/getComponent.nested.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.nested.test.js
@@ -1,7 +1,7 @@
 // Global imports
 import { render } from '@testing-library/react';
 // Local imports
-import { getNestedComponents } from '../getComponent';
+import { getChildrenJsx } from '../getComponent';
 
 describe('utils.Component.get', () => {
   it('should return components that are nested within another component', async () => {
@@ -34,7 +34,7 @@ describe('utils.Component.get', () => {
         type: 'date',
       },
     ];
-    const { container } = render(getNestedComponents(PARENT_CONFIG, NESTED_CONFIG));
+    const { container } = render(getChildrenJsx(PARENT_CONFIG, NESTED_CONFIG));
     const child = container.childNodes[0];
     expect(child.childNodes.length).toEqual(3);
     expect(child.classList).toContain('govuk-form-group');
@@ -88,8 +88,8 @@ describe('utils.Component.get', () => {
         readonly: true,
       },
     ];
-    const { container } = render(getNestedComponents(PARENT_CONFIG, NESTED_CONFIG));
-    const child = container.childNodes[0];
+    const { container } = render(getChildrenJsx(PARENT_CONFIG, NESTED_CONFIG));
+    const child = container.childNodes[0].childNodes[0];
     expect(child.classList).toContain('hods-readonly');
   });
 });

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -20,7 +20,6 @@ const validateComponent = (component, formData) => {
     return undefined;
   }
   let error = undefined;
-  let nestedId = undefined;
   let propertiesInError = undefined;
   const data = formData && typeof formData === 'object' ? formData : {};
 
@@ -66,7 +65,7 @@ const validateComponent = (component, formData) => {
 
   if (error) {
     return {
-      id: nestedId || component.full_path || component.id,
+      id: component.full_path || component.id,
       error: error,
       properties: propertiesInError
     };

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -46,18 +46,15 @@ const validateComponent = (component, formData) => {
         error = message;
         break;
       case ComponentTypes.RADIOS:
-        component.data.options?.some((option) => {
-          let nestedError;
-          if (option.nested && option.nested.shown) {
-            nestedError = validateComponent(option.nested, formData);
-            error = nestedError?.error;
-            if (nestedError) {
-              nestedId = nestedError.id;
-            }
+        let nestedErrors = [];
+        console.log(component.data.options);
+        component.data.options?.forEach((option) => {
+          console.log("Validating option: " + JSON.stringify(option));
+          if (option.nested && option.shown) {
+            nestedErrors.concat(validateContainer({components: option.nested}, formData));
           }
-          return nestedError;
         });
-        break;
+        return nestedErrors;
       default:
         break;
     }

--- a/src/utils/Validate/validateComponent.js
+++ b/src/utils/Validate/validateComponent.js
@@ -47,11 +47,9 @@ const validateComponent = (component, formData) => {
         break;
       case ComponentTypes.RADIOS:
         let nestedErrors = [];
-        console.log(component.data.options);
         component.data.options?.forEach((option) => {
-          console.log("Validating option: " + JSON.stringify(option));
-          if (option.nested && option.shown) {
-            nestedErrors.concat(validateContainer({components: option.nested}, formData));
+          if (option.nested && (formData[component.id] === option.value)) {
+            nestedErrors = nestedErrors.concat( validateContainer({ components: option.nested }, formData));
           }
         });
         return nestedErrors;

--- a/src/utils/Validate/validateComponent.test.js
+++ b/src/utils/Validate/validateComponent.test.js
@@ -3,7 +3,7 @@ import { ComponentTypes } from '../../models';
 import validateComponent from './validateComponent';
 
 describe('utils.Validate.Component', () => {
-    
+
       const setup = (id, type, label, required, additionalValidation) => {
         return { id, fieldId: id, type, label, required, additionalValidation };
       };
@@ -27,7 +27,7 @@ describe('utils.Validate.Component', () => {
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
           expect(validateComponent(COMPONENT, null)).toEqual({
             id: ID,
-            error: `${LABEL} is required`,
+            error: `${LABEL} is required`
           });
         });
   
@@ -37,7 +37,7 @@ describe('utils.Validate.Component', () => {
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
           expect(validateComponent(COMPONENT, null)).toEqual({
             id: ID,
-            error: `${LABEL} is required`,
+            error: `${LABEL} is required`
           });
         });
   
@@ -49,7 +49,7 @@ describe('utils.Validate.Component', () => {
         });
 
       });
-  
+
       describe('when the value is fully valid', () => {
         const ID = 'field';
         const DATA = { [ID]: 'alpha.bravo@digital.homeoffice.gov.uk' };
@@ -101,7 +101,7 @@ describe('utils.Validate.Component', () => {
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
           expect(validateComponent(COMPONENT, DATA)).toEqual({
             id: ID,
-            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
+            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
           });
         });
   
@@ -110,7 +110,7 @@ describe('utils.Validate.Component', () => {
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
           expect(validateComponent(COMPONENT, DATA)).toEqual({
             id: ID,
-            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
+            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
           });
         });
 
@@ -172,7 +172,7 @@ describe('utils.Validate.Component', () => {
           const DATA = {
             [ID]: {
               [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk'
-            },
+            }
           };
           expect(validateComponent(CONTAINER, DATA)).toEqual([]);
         });
@@ -188,7 +188,10 @@ describe('utils.Validate.Component', () => {
           const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false);
           COLLECTION.item = [EMAIL];
           const DATA = {
-            [ID]: [{ [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }]
+            [ID]: [
+              { [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, 
+              { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }
+            ]
           };
           expect(validateComponent(COLLECTION, DATA)).toEqual([]);
         });
@@ -243,7 +246,7 @@ describe('utils.Validate.Component', () => {
           };
           expect(validateComponent(COMPONENT, FORMDATA)).toEqual([{
             id: NESTED_ID,
-            error: `Field is required`,
+            error: `Field is required`
           }]);
         });
 

--- a/src/utils/Validate/validateComponent.test.js
+++ b/src/utils/Validate/validateComponent.test.js
@@ -3,7 +3,7 @@ import { ComponentTypes } from '../../models';
 import validateComponent from './validateComponent';
 
 describe('utils.Validate.Component', () => {
-  
+    
       const setup = (id, type, label, required, additionalValidation) => {
         return { id, fieldId: id, type, label, required, additionalValidation };
       };
@@ -13,13 +13,14 @@ describe('utils.Validate.Component', () => {
       });
 
       describe('when there is no form data', () => {
+
         it('should return no error when the component is not required and not an email type', () => {
           const ID = 'field';
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
           expect(validateComponent(COMPONENT, null)).toBeUndefined();
         });
-
+  
         it('should return a required error when the component is required and not an email type', () => {
           const ID = 'field';
           const LABEL = 'Field';
@@ -29,7 +30,7 @@ describe('utils.Validate.Component', () => {
             error: `${LABEL} is required`,
           });
         });
-
+  
         it('should return a required error when the component is required and of type email', () => {
           const ID = 'field';
           const LABEL = 'Field';
@@ -39,15 +40,16 @@ describe('utils.Validate.Component', () => {
             error: `${LABEL} is required`,
           });
         });
-
+  
         it('should return no error when the component is of type email but not required', () => {
           const ID = 'field';
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
           expect(validateComponent(COMPONENT, null)).toBeUndefined();
         });
-      });
 
+      });
+  
       describe('when the value is fully valid', () => {
         const ID = 'field';
         const DATA = { [ID]: 'alpha.bravo@digital.homeoffice.gov.uk' };
@@ -57,24 +59,25 @@ describe('utils.Validate.Component', () => {
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
         });
-
+  
         it('should return no error when the component is required and not an email type', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
         });
-
+  
         it('should return no error when the component is required and of type email', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
         });
-
+  
         it('should return no error when the component is of type email but not required', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
         });
+
       });
 
       describe('when the value is an invalid email', () => {
@@ -86,13 +89,13 @@ describe('utils.Validate.Component', () => {
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
         });
-
+  
         it('should return no error when the component is required and not an email type', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
           expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
         });
-
+  
         it('should return no error when the component is required and of type email', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
@@ -101,7 +104,7 @@ describe('utils.Validate.Component', () => {
             error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
           });
         });
-
+  
         it('should return no error when the component is of type email but not required', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
@@ -110,11 +113,12 @@ describe('utils.Validate.Component', () => {
             error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
           });
         });
-      });
 
+      });
+  
       describe('when the component is a Date Input', () => {
         const ID = 'field';
-
+        
         it('should always reject invalid dates', () => {
           const LABEL = 'Field';
           const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false);
@@ -122,10 +126,10 @@ describe('utils.Validate.Component', () => {
           expect(validateComponent(COMPONENT, DATA)).toEqual({
             error: 'Month must be between 1 and 12',
             id: ID,
-            properties: { month: true },
+            properties: { month: true }
           });
         });
-
+        
         it('should apply optional validators when specified', () => {
           const LABEL = 'Field';
           const DATA = { [ID]: '25-3-3033' };
@@ -136,7 +140,7 @@ describe('utils.Validate.Component', () => {
           expect(validateComponent(COMPONENT, DATA)).toEqual({
             error: 'Date must be less than 3 days in the future',
             id: ID,
-            properties: { day: true, month: true, year: true },
+            properties: { day: true, month: true, year: true }
           });
         });
       });
@@ -150,9 +154,10 @@ describe('utils.Validate.Component', () => {
           expect(validateComponent(COMPONENT, DATA)).toEqual({
             error: 'Hour must be between 0 and 23',
             id: ID,
-            properties: { hour: true },
+            properties: { hour: true }
           });
         });
+
       });
 
       describe('when the component is a container', () => {
@@ -166,7 +171,7 @@ describe('utils.Validate.Component', () => {
           CONTAINER.components = [EMAIL];
           const DATA = {
             [ID]: {
-              [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk',
+              [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk'
             },
           };
           expect(validateComponent(CONTAINER, DATA)).toEqual([]);
@@ -183,7 +188,7 @@ describe('utils.Validate.Component', () => {
           const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false);
           COLLECTION.item = [EMAIL];
           const DATA = {
-            [ID]: [{ [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }],
+            [ID]: [{ [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }]
           };
           expect(validateComponent(COLLECTION, DATA)).toEqual([]);
         });
@@ -205,8 +210,7 @@ describe('utils.Validate.Component', () => {
                       type: 'text',
                       fieldId: NESTED_ID,
                       id: NESTED_ID,
-                      required: true,
-                      shown: true,
+                      required: true
                     },
                   ],
                 },
@@ -230,8 +234,7 @@ describe('utils.Validate.Component', () => {
                       type: 'text',
                       fieldId: NESTED_ID,
                       id: NESTED_ID,
-                      required: true,
-                      shown: true,
+                      required: true
                     },
                   ],
                 },
@@ -258,7 +261,7 @@ describe('utils.Validate.Component', () => {
                       type: 'text',
                       fieldId: NESTED_ID,
                       id: NESTED_ID,
-                      required: true,
+                      required: true
                     },
                   ],
                 },

--- a/src/utils/Validate/validateComponent.test.js
+++ b/src/utils/Validate/validateComponent.test.js
@@ -3,268 +3,269 @@ import { ComponentTypes } from '../../models';
 import validateComponent from './validateComponent';
 
 describe('utils.Validate.Component', () => {
-  const setup = (id, type, label, required, additionalValidation) => {
-    return { id, fieldId: id, type, label, required, additionalValidation };
-  };
-
-  it('should return no error when the component is null', () => {
-    expect(validateComponent(null, {})).toBeUndefined();
-  });
-
-  describe('when there is no form data', () => {
-    it('should return no error when the component is not required and not an email type', () => {
-      const ID = 'field';
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
-      expect(validateComponent(COMPONENT, null)).toBeUndefined();
-    });
-
-    it('should return a required error when the component is required and not an email type', () => {
-      const ID = 'field';
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
-      expect(validateComponent(COMPONENT, null)).toEqual({
-        id: ID,
-        error: `${LABEL} is required`,
-      });
-    });
-
-    it('should return a required error when the component is required and of type email', () => {
-      const ID = 'field';
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
-      expect(validateComponent(COMPONENT, null)).toEqual({
-        id: ID,
-        error: `${LABEL} is required`,
-      });
-    });
-
-    it('should return no error when the component is of type email but not required', () => {
-      const ID = 'field';
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
-      expect(validateComponent(COMPONENT, null)).toBeUndefined();
-    });
-  });
-
-  describe('when the value is fully valid', () => {
-    const ID = 'field';
-    const DATA = { [ID]: 'alpha.bravo@digital.homeoffice.gov.uk' };
-
-    it('should return no error when the component is not required and not an email type', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
-      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-    });
-
-    it('should return no error when the component is required and not an email type', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
-      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-    });
-
-    it('should return no error when the component is required and of type email', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
-      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-    });
-
-    it('should return no error when the component is of type email but not required', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
-      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-    });
-  });
-
-  describe('when the value is an invalid email', () => {
-    const ID = 'field';
-    const DATA = { [ID]: 'alpha.bravo@hotmail.com' };
-
-    it('should return no error when the component is not required and not an email type', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
-      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-    });
-
-    it('should return no error when the component is required and not an email type', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
-      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-    });
-
-    it('should return no error when the component is required and of type email', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
-      expect(validateComponent(COMPONENT, DATA)).toEqual({
-        id: ID,
-        error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
-      });
-    });
-
-    it('should return no error when the component is of type email but not required', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
-      expect(validateComponent(COMPONENT, DATA)).toEqual({
-        id: ID,
-        error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
-      });
-    });
-  });
-
-  describe('when the component is a Date Input', () => {
-    const ID = 'field';
-
-    it('should always reject invalid dates', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false);
-      const DATA = { [ID]: '25-45-2033' };
-      expect(validateComponent(COMPONENT, DATA)).toEqual({
-        error: 'Month must be between 1 and 12',
-        id: ID,
-        properties: { month: true },
-      });
-    });
-
-    it('should apply optional validators when specified', () => {
-      const LABEL = 'Field';
-      const DATA = { [ID]: '25-3-3033' };
-      const ADDITIONAL_VALIDATION = [
-        { function: 'mustBeBefore', value: 3, unit: 'day', message: 'Date must be less than 3 days in the future' },
-      ];
-      const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false, ADDITIONAL_VALIDATION);
-      expect(validateComponent(COMPONENT, DATA)).toEqual({
-        error: 'Date must be less than 3 days in the future',
-        id: ID,
-        properties: { day: true, month: true, year: true },
-      });
-    });
-  });
-
-  describe('when the component is a Time Input', () => {
-    const ID = 'field';
-    it('should always reject invalid time', () => {
-      const LABEL = 'Field';
-      const COMPONENT = setup(ID, ComponentTypes.TIME, LABEL, false);
-      const DATA = { [ID]: '25:45' };
-      expect(validateComponent(COMPONENT, DATA)).toEqual({
-        error: 'Hour must be between 0 and 23',
-        id: ID,
-        properties: { hour: true },
-      });
-    });
-  });
-
-  describe('when the component is a container', () => {
-    it('should return an empty array when the container has only valid components', () => {
-      const EMAIL_ID = 'email';
-      const EMAIL_LABEL = 'Email';
-      const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
-      const ID = 'container';
-      const LABEL = 'field';
-      const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
-      CONTAINER.components = [EMAIL];
-      const DATA = {
-        [ID]: {
-          [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk',
-        },
+  
+      const setup = (id, type, label, required, additionalValidation) => {
+        return { id, fieldId: id, type, label, required, additionalValidation };
       };
-      expect(validateComponent(CONTAINER, DATA)).toEqual([]);
-    });
-  });
 
-  describe('when the component is a collection', () => {
-    it('should return an empty array when the collection has only valid items', () => {
-      const EMAIL_ID = 'email';
-      const EMAIL_LABEL = 'Email';
-      const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
-      const ID = 'collection';
-      const LABEL = 'field';
-      const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false);
-      COLLECTION.item = [EMAIL];
-      const DATA = {
-        [ID]: [{ [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }],
-      };
-      expect(validateComponent(COLLECTION, DATA)).toEqual([]);
-    });
-  });
+      it('should return no error when the component is null', () => {
+        expect(validateComponent(null, {})).toBeUndefined();
+      });
 
-  describe('when the component has a nested component', () => {
-    it('should return no error when the radio component contains nested components without errors', () => {
-      const NESTED_ID = 'nestedId';
-      const NESTED_VALUE = 'nestedValue';
-      const FORMDATA = { [NESTED_ID]: NESTED_VALUE };
-      const COMPONENT = {
-        type: 'radios',
-        id: 'a',
-        data: {
-          options: [
-            {
-              nested: [
+      describe('when there is no form data', () => {
+        it('should return no error when the component is not required and not an email type', () => {
+          const ID = 'field';
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+          expect(validateComponent(COMPONENT, null)).toBeUndefined();
+        });
+
+        it('should return a required error when the component is required and not an email type', () => {
+          const ID = 'field';
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+          expect(validateComponent(COMPONENT, null)).toEqual({
+            id: ID,
+            error: `${LABEL} is required`,
+          });
+        });
+
+        it('should return a required error when the component is required and of type email', () => {
+          const ID = 'field';
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+          expect(validateComponent(COMPONENT, null)).toEqual({
+            id: ID,
+            error: `${LABEL} is required`,
+          });
+        });
+
+        it('should return no error when the component is of type email but not required', () => {
+          const ID = 'field';
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+          expect(validateComponent(COMPONENT, null)).toBeUndefined();
+        });
+      });
+
+      describe('when the value is fully valid', () => {
+        const ID = 'field';
+        const DATA = { [ID]: 'alpha.bravo@digital.homeoffice.gov.uk' };
+
+        it('should return no error when the component is not required and not an email type', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+
+        it('should return no error when the component is required and not an email type', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+
+        it('should return no error when the component is required and of type email', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+
+        it('should return no error when the component is of type email but not required', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+      });
+
+      describe('when the value is an invalid email', () => {
+        const ID = 'field';
+        const DATA = { [ID]: 'alpha.bravo@hotmail.com' };
+
+        it('should return no error when the component is not required and not an email type', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+
+        it('should return no error when the component is required and not an email type', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+        });
+
+        it('should return no error when the component is required and of type email', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            id: ID,
+            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
+          });
+        });
+
+        it('should return no error when the component is of type email but not required', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            id: ID,
+            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
+          });
+        });
+      });
+
+      describe('when the component is a Date Input', () => {
+        const ID = 'field';
+
+        it('should always reject invalid dates', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false);
+          const DATA = { [ID]: '25-45-2033' };
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            error: 'Month must be between 1 and 12',
+            id: ID,
+            properties: { month: true },
+          });
+        });
+
+        it('should apply optional validators when specified', () => {
+          const LABEL = 'Field';
+          const DATA = { [ID]: '25-3-3033' };
+          const ADDITIONAL_VALIDATION = [
+            { function: 'mustBeBefore', value: 3, unit: 'day', message: 'Date must be less than 3 days in the future' },
+          ];
+          const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false, ADDITIONAL_VALIDATION);
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            error: 'Date must be less than 3 days in the future',
+            id: ID,
+            properties: { day: true, month: true, year: true },
+          });
+        });
+      });
+
+      describe('when the component is a Time Input', () => {
+        const ID = 'field';
+        it('should always reject invalid time', () => {
+          const LABEL = 'Field';
+          const COMPONENT = setup(ID, ComponentTypes.TIME, LABEL, false);
+          const DATA = { [ID]: '25:45' };
+          expect(validateComponent(COMPONENT, DATA)).toEqual({
+            error: 'Hour must be between 0 and 23',
+            id: ID,
+            properties: { hour: true },
+          });
+        });
+      });
+
+      describe('when the component is a container', () => {
+        it('should return an empty array when the container has only valid components', () => {
+          const EMAIL_ID = 'email';
+          const EMAIL_LABEL = 'Email';
+          const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+          const ID = 'container';
+          const LABEL = 'field';
+          const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
+          CONTAINER.components = [EMAIL];
+          const DATA = {
+            [ID]: {
+              [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk',
+            },
+          };
+          expect(validateComponent(CONTAINER, DATA)).toEqual([]);
+        });
+      });
+
+      describe('when the component is a collection', () => {
+        it('should return an empty array when the collection has only valid items', () => {
+          const EMAIL_ID = 'email';
+          const EMAIL_LABEL = 'Email';
+          const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+          const ID = 'collection';
+          const LABEL = 'field';
+          const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false);
+          COLLECTION.item = [EMAIL];
+          const DATA = {
+            [ID]: [{ [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }],
+          };
+          expect(validateComponent(COLLECTION, DATA)).toEqual([]);
+        });
+      });
+
+      describe('when the component has a nested component', () => {
+        it('should return no error when the radio component contains nested components without errors', () => {
+          const NESTED_ID = 'nestedId';
+          const NESTED_VALUE = 'nestedValue';
+          const FORMDATA = { [NESTED_ID]: NESTED_VALUE };
+          const COMPONENT = {
+            type: 'radios',
+            id: 'a',
+            data: {
+              options: [
                 {
-                  type: 'text',
-                  fieldId: NESTED_ID,
-                  id: NESTED_ID,
-                  required: true,
-                  shown: true,
+                  nested: [
+                    {
+                      type: 'text',
+                      fieldId: NESTED_ID,
+                      id: NESTED_ID,
+                      required: true,
+                      shown: true,
+                    },
+                  ],
                 },
               ],
             },
-          ],
-        },
-      };
-      expect(validateComponent(COMPONENT, FORMDATA)).toEqual([]);
-    });
+          };
+          expect(validateComponent(COMPONENT, FORMDATA)).toEqual([]);
+        });
 
-    it('should return an error when the radio component contains nested components with errors', () => {
-      const NESTED_ID = 'nestedId';
-      const FORMDATA = {};
-      const COMPONENT = {
-        type: 'radios',
-        id: 'a',
-        data: {
-          options: [
-            {
-              nested: [
+        it('should return an error when the radio component contains nested components with errors', () => {
+          const NESTED_ID = 'nestedId';
+          const FORMDATA = {};
+          const COMPONENT = {
+            type: 'radios',
+            id: 'a',
+            data: {
+              options: [
                 {
-                  type: 'text',
-                  fieldId: NESTED_ID,
-                  id: NESTED_ID,
-                  required: true,
-                  shown: true,
+                  nested: [
+                    {
+                      type: 'text',
+                      fieldId: NESTED_ID,
+                      id: NESTED_ID,
+                      required: true,
+                      shown: true,
+                    },
+                  ],
                 },
               ],
             },
-          ],
-        },
-      };
-      expect(validateComponent(COMPONENT, FORMDATA)).toEqual([{
-        id: NESTED_ID,
-        error: `Field is required`,
-      }]);
-    });
+          };
+          expect(validateComponent(COMPONENT, FORMDATA)).toEqual([{
+            id: NESTED_ID,
+            error: `Field is required`,
+          }]);
+        });
 
-    it('should return no error when a non selected radio component contains nested components with errors', () => {
-      const NESTED_ID = 'nestedId';
-      const COMPONENT = {
-        type: 'radios',
-        id: 'a',
-        data: {
-          options: [
-            {
-              value: 'optionValue',
-              nested: [
+        it('should return no error when a non selected radio component contains nested components with errors', () => {
+          const NESTED_ID = 'nestedId';
+          const COMPONENT = {
+            type: 'radios',
+            id: 'a',
+            data: {
+              options: [
                 {
-                  type: 'text',
-                  fieldId: NESTED_ID,
-                  id: NESTED_ID,
-                  required: true,
+                  value: 'optionValue',
+                  nested: [
+                    {
+                      type: 'text',
+                      fieldId: NESTED_ID,
+                      id: NESTED_ID,
+                      required: true,
+                    },
+                  ],
                 },
               ],
             },
-          ],
-        },
-      };
-      expect(validateComponent(COMPONENT, {})).toEqual([]);
-    });
-  });
+          };
+          expect(validateComponent(COMPONENT, {})).toEqual([]);
+        });
+      });
 });

--- a/src/utils/Validate/validateComponent.test.js
+++ b/src/utils/Validate/validateComponent.test.js
@@ -220,7 +220,7 @@ describe('utils.Validate.Component', () => {
               ],
             },
           };
-          expect(validateComponent(COMPONENT, FORMDATA)).toEqual([]);
+          expect(validateComponent(COMPONENT, undefined, FORMDATA)).toEqual([]);
         });
 
         it('should return an error when the radio component contains nested components with errors', () => {
@@ -244,7 +244,7 @@ describe('utils.Validate.Component', () => {
               ],
             },
           };
-          expect(validateComponent(COMPONENT, FORMDATA)).toEqual([{
+          expect(validateComponent(COMPONENT, undefined, FORMDATA)).toEqual([{
             id: NESTED_ID,
             error: `Field is required`
           }]);
@@ -271,7 +271,7 @@ describe('utils.Validate.Component', () => {
               ],
             },
           };
-          expect(validateComponent(COMPONENT, {})).toEqual([]);
+          expect(validateComponent(COMPONENT, undefined, {})).toEqual([]);
         });
       });
 });

--- a/src/utils/Validate/validateComponent.test.js
+++ b/src/utils/Validate/validateComponent.test.js
@@ -3,273 +3,268 @@ import { ComponentTypes } from '../../models';
 import validateComponent from './validateComponent';
 
 describe('utils.Validate.Component', () => {
+  const setup = (id, type, label, required, additionalValidation) => {
+    return { id, fieldId: id, type, label, required, additionalValidation };
+  };
 
-      const setup = (id, type, label, required, additionalValidation) => {
-        return { id, fieldId: id, type, label, required, additionalValidation };
+  it('should return no error when the component is null', () => {
+    expect(validateComponent(null, {})).toBeUndefined();
+  });
+
+  describe('when there is no form data', () => {
+    it('should return no error when the component is not required and not an email type', () => {
+      const ID = 'field';
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+      expect(validateComponent(COMPONENT, null)).toBeUndefined();
+    });
+
+    it('should return a required error when the component is required and not an email type', () => {
+      const ID = 'field';
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+      expect(validateComponent(COMPONENT, null)).toEqual({
+        id: ID,
+        error: `${LABEL} is required`,
+      });
+    });
+
+    it('should return a required error when the component is required and of type email', () => {
+      const ID = 'field';
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+      expect(validateComponent(COMPONENT, null)).toEqual({
+        id: ID,
+        error: `${LABEL} is required`,
+      });
+    });
+
+    it('should return no error when the component is of type email but not required', () => {
+      const ID = 'field';
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+      expect(validateComponent(COMPONENT, null)).toBeUndefined();
+    });
+  });
+
+  describe('when the value is fully valid', () => {
+    const ID = 'field';
+    const DATA = { [ID]: 'alpha.bravo@digital.homeoffice.gov.uk' };
+
+    it('should return no error when the component is not required and not an email type', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+    });
+
+    it('should return no error when the component is required and not an email type', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+    });
+
+    it('should return no error when the component is required and of type email', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+    });
+
+    it('should return no error when the component is of type email but not required', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+    });
+  });
+
+  describe('when the value is an invalid email', () => {
+    const ID = 'field';
+    const DATA = { [ID]: 'alpha.bravo@hotmail.com' };
+
+    it('should return no error when the component is not required and not an email type', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
+      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+    });
+
+    it('should return no error when the component is required and not an email type', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
+      expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
+    });
+
+    it('should return no error when the component is required and of type email', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
+      expect(validateComponent(COMPONENT, DATA)).toEqual({
+        id: ID,
+        error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
+      });
+    });
+
+    it('should return no error when the component is of type email but not required', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
+      expect(validateComponent(COMPONENT, DATA)).toEqual({
+        id: ID,
+        error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`,
+      });
+    });
+  });
+
+  describe('when the component is a Date Input', () => {
+    const ID = 'field';
+
+    it('should always reject invalid dates', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false);
+      const DATA = { [ID]: '25-45-2033' };
+      expect(validateComponent(COMPONENT, DATA)).toEqual({
+        error: 'Month must be between 1 and 12',
+        id: ID,
+        properties: { month: true },
+      });
+    });
+
+    it('should apply optional validators when specified', () => {
+      const LABEL = 'Field';
+      const DATA = { [ID]: '25-3-3033' };
+      const ADDITIONAL_VALIDATION = [
+        { function: 'mustBeBefore', value: 3, unit: 'day', message: 'Date must be less than 3 days in the future' },
+      ];
+      const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false, ADDITIONAL_VALIDATION);
+      expect(validateComponent(COMPONENT, DATA)).toEqual({
+        error: 'Date must be less than 3 days in the future',
+        id: ID,
+        properties: { day: true, month: true, year: true },
+      });
+    });
+  });
+
+  describe('when the component is a Time Input', () => {
+    const ID = 'field';
+    it('should always reject invalid time', () => {
+      const LABEL = 'Field';
+      const COMPONENT = setup(ID, ComponentTypes.TIME, LABEL, false);
+      const DATA = { [ID]: '25:45' };
+      expect(validateComponent(COMPONENT, DATA)).toEqual({
+        error: 'Hour must be between 0 and 23',
+        id: ID,
+        properties: { hour: true },
+      });
+    });
+  });
+
+  describe('when the component is a container', () => {
+    it('should return an empty array when the container has only valid components', () => {
+      const EMAIL_ID = 'email';
+      const EMAIL_LABEL = 'Email';
+      const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+      const ID = 'container';
+      const LABEL = 'field';
+      const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
+      CONTAINER.components = [EMAIL];
+      const DATA = {
+        [ID]: {
+          [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk',
+        },
       };
+      expect(validateComponent(CONTAINER, DATA)).toEqual([]);
+    });
+  });
 
-      it('should return no error when the component is null', () => {
-        expect(validateComponent(null, {})).toBeUndefined();
-      });
+  describe('when the component is a collection', () => {
+    it('should return an empty array when the collection has only valid items', () => {
+      const EMAIL_ID = 'email';
+      const EMAIL_LABEL = 'Email';
+      const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
+      const ID = 'collection';
+      const LABEL = 'field';
+      const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false);
+      COLLECTION.item = [EMAIL];
+      const DATA = {
+        [ID]: [{ [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' }, { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }],
+      };
+      expect(validateComponent(COLLECTION, DATA)).toEqual([]);
+    });
+  });
 
-      describe('when there is no form data', () => {
-
-        it('should return no error when the component is not required and not an email type', () => {
-          const ID = 'field';
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
-          expect(validateComponent(COMPONENT, null)).toBeUndefined();
-        });
-  
-        it('should return a required error when the component is required and not an email type', () => {
-          const ID = 'field';
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
-          expect(validateComponent(COMPONENT, null)).toEqual({
-            id: ID,
-            error: `${LABEL} is required`
-          });
-        });
-  
-        it('should return a required error when the component is required and of type email', () => {
-          const ID = 'field';
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
-          expect(validateComponent(COMPONENT, null)).toEqual({
-            id: ID,
-            error: `${LABEL} is required`
-          });
-        });
-  
-        it('should return no error when the component is of type email but not required', () => {
-          const ID = 'field';
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
-          expect(validateComponent(COMPONENT, null)).toBeUndefined();
-        });
-
-      });
-
-      describe('when the value is fully valid', () => {
-        const ID = 'field';
-        const DATA = { [ID]: 'alpha.bravo@digital.homeoffice.gov.uk' };
-
-        it('should return no error when the component is not required and not an email type', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
-          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-        });
-  
-        it('should return no error when the component is required and not an email type', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
-          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-        });
-  
-        it('should return no error when the component is required and of type email', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
-          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-        });
-  
-        it('should return no error when the component is of type email but not required', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
-          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-        });
-
-      });
-
-      describe('when the value is an invalid email', () => {
-        const ID = 'field';
-        const DATA = { [ID]: 'alpha.bravo@hotmail.com' };
-
-        it('should return no error when the component is not required and not an email type', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, false);
-          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-        });
-  
-        it('should return no error when the component is required and not an email type', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TEXT, LABEL, true);
-          expect(validateComponent(COMPONENT, DATA)).toBeUndefined();
-        });
-  
-        it('should return no error when the component is required and of type email', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, true);
-          expect(validateComponent(COMPONENT, DATA)).toEqual({
-            id: ID,
-            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
-          });
-        });
-  
-        it('should return no error when the component is of type email but not required', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.EMAIL, LABEL, false);
-          expect(validateComponent(COMPONENT, DATA)).toEqual({
-            id: ID,
-            error: `Enter ${LABEL.toLowerCase()} in the correct format, like jane.doe@homeoffice.gov.uk`
-          });
-        });
-
-      });
-  
-      describe('when the component is a Date Input', () => {
-        const ID = 'field';
-        
-        it('should always reject invalid dates', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false);
-          const DATA = { [ID]: '25-45-2033' };
-          expect(validateComponent(COMPONENT, DATA)).toEqual({
-            error: 'Month must be between 1 and 12',
-            id: ID,
-            properties: { month: true }
-          });
-        });
-        
-        it('should apply optional validators when specified', () => {
-          const LABEL = 'Field';
-          const DATA = { [ID]: '25-3-3033' };
-          const ADDITIONAL_VALIDATION = [
-            { function: 'mustBeBefore', value: 3, unit: 'day', message: 'Date must be less than 3 days in the future' },
-          ]
-          const COMPONENT = setup(ID, ComponentTypes.DATE, LABEL, false, ADDITIONAL_VALIDATION);
-          expect(validateComponent(COMPONENT, DATA)).toEqual({
-            error: 'Date must be less than 3 days in the future',
-            id: ID,
-            properties: { day: true, month: true, year: true }
-          });
-        });
-
-      });
-
-      describe('when the component is a Time Input', () => {
-        const ID = 'field';
-        it('should always reject invalid time', () => {
-          const LABEL = 'Field';
-          const COMPONENT = setup(ID, ComponentTypes.TIME, LABEL, false);
-          const DATA = { [ID]: '25:45' };
-          expect(validateComponent(COMPONENT, DATA)).toEqual({
-            error: 'Hour must be between 0 and 23',
-            id: ID,
-            properties: { hour: true }
-          });
-        });
-
-      });
-
-      describe('when the component is a container', () => {
-        it('should return an empty array when the container has only valid components', () => {
-          const EMAIL_ID = 'email';
-          const EMAIL_LABEL = 'Email';
-          const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
-          const ID = 'container';
-          const LABEL = 'field';
-          const CONTAINER = setup(ID, ComponentTypes.CONTAINER, LABEL, false);
-          CONTAINER.components = [EMAIL];
-          const DATA = {
-            [ID]: {
-              [EMAIL_ID]: 'alpha.bravo@digital.homeoffice.gov.uk'
-            }
-          };
-          expect(validateComponent(CONTAINER, DATA)).toEqual([]);
-        });
-      });
-
-      describe('when the component is a collection', () => {
-        it('should return an empty array when the collection has only valid items', () => {
-          const EMAIL_ID = 'email';
-          const EMAIL_LABEL = 'Email';
-          const EMAIL = setup(EMAIL_ID, ComponentTypes.EMAIL, EMAIL_LABEL, false);
-          const ID = 'collection';
-          const LABEL = 'field';
-          const COLLECTION = setup(ID, ComponentTypes.COLLECTION, LABEL, false);
-          COLLECTION.item = [EMAIL];
-          const DATA = {
-            [ID]: [
-              { [EMAIL_ID]: 'alpha.bravo@homeoffice.gov.uk' },
-              { [EMAIL_ID]: 'charlie.delta@homeoffice.gov.uk' }
-            ]
-          };
-          expect(validateComponent(COLLECTION, DATA)).toEqual([]);
-        });
-      });
-
-      describe('when the component has a nested component', () => {
-
-        it('should return no error when the radio component contains nested components without errors', () => {
-          const NESTED_ID = 'nestedId';
-          const NESTED_VALUE = 'nestedValue';
-          const FORMDATA = { [NESTED_ID]: NESTED_VALUE }
-          const COMPONENT = {
-            type: 'radios',
-            id: 'a',
-            data: {
-              options: [
+  describe('when the component has a nested component', () => {
+    it('should return no error when the radio component contains nested components without errors', () => {
+      const NESTED_ID = 'nestedId';
+      const NESTED_VALUE = 'nestedValue';
+      const FORMDATA = { [NESTED_ID]: NESTED_VALUE };
+      const COMPONENT = {
+        type: 'radios',
+        id: 'a',
+        data: {
+          options: [
+            {
+              nested: [
                 {
-                  nested: {
-                    type: 'text',
-                    fieldId: NESTED_ID,
-                    id: NESTED_ID,
-                    required: true,
-                    shown: true
-                  },
-                }
+                  type: 'text',
+                  fieldId: NESTED_ID,
+                  id: NESTED_ID,
+                  required: true,
+                  shown: true,
+                },
               ],
             },
-          }; 
-          expect(validateComponent(COMPONENT, FORMDATA)).toBeUndefined();
-        });
+          ],
+        },
+      };
+      expect(validateComponent(COMPONENT, FORMDATA)).toEqual([]);
+    });
 
-        it('should return an error when the radio component contains nested components with errors', () => {
-          const NESTED_ID = 'nestedId';
-          const FORMDATA = {}
-          const COMPONENT = {
-            type: 'radios',
-            id: 'a',
-            data: {
-              options: [
+    it('should return an error when the radio component contains nested components with errors', () => {
+      const NESTED_ID = 'nestedId';
+      const FORMDATA = {};
+      const COMPONENT = {
+        type: 'radios',
+        id: 'a',
+        data: {
+          options: [
+            {
+              nested: [
                 {
-                  nested: {
-                    type: 'text',
-                    fieldId: NESTED_ID,
-                    id: NESTED_ID,
-                    required: true,
-                    shown: true
-                  },
-                }
+                  type: 'text',
+                  fieldId: NESTED_ID,
+                  id: NESTED_ID,
+                  required: true,
+                  shown: true,
+                },
               ],
             },
-          }; 
-          expect(validateComponent(COMPONENT, FORMDATA)).toEqual({
-            id: NESTED_ID,
-            error: `Field is required`
-          });
-        });
+          ],
+        },
+      };
+      expect(validateComponent(COMPONENT, FORMDATA)).toEqual([{
+        id: NESTED_ID,
+        error: `Field is required`,
+      }]);
+    });
 
-        it('should return no error when a non selected radio component contains nested components with errors', () => {
-          const NESTED_ID = 'nestedId';
-          const COMPONENT = {
-            type: 'radios',
-            id: 'a',
-            data: {
-              options: [
+    it('should return no error when a non selected radio component contains nested components with errors', () => {
+      const NESTED_ID = 'nestedId';
+      const COMPONENT = {
+        type: 'radios',
+        id: 'a',
+        data: {
+          options: [
+            {
+              value: 'optionValue',
+              nested: [
                 {
-                  nested: {
-                    type: 'text',
-                    fieldId: NESTED_ID,
-                    id: NESTED_ID,
-                    required: true
-                  },
-                }
+                  type: 'text',
+                  fieldId: NESTED_ID,
+                  id: NESTED_ID,
+                  required: true,
+                },
               ],
             },
-          }; 
-          expect(validateComponent(COMPONENT, {})).toBeUndefined();
-        });
-      });
-
+          ],
+        },
+      };
+      expect(validateComponent(COMPONENT, {})).toEqual([]);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.6.0.tgz#154fb4d4d8d2bc8f000cfaa47590a6f4932107f1"
-  integrity sha512-xnP6FGuut3vrHJ54ZpG2PJjVthA/GwE2VvZGIzqQ9cLHRq7SLo1bzQ0rbf2kzD3HCYTKx5ai3vD7hpSQMpGbwA==
+"@ukhomeoffice/cop-react-components@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.7.3.tgz#5e67af84cf9052dc1e694ea7655b2305b33d32fe"
+  integrity sha512-sCeWCH0VYhaI7zOf/TE5NdsKdE9BmsBQDAfnt+irpKgWsi/GhvbV12GkTHhUUoCTJv4p/RlIzgPuDQcHLDu6Iw==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"


### PR DESCRIPTION
Update form-renderer to provide multiple child components per radio button when specified by the JSON config. 

Additionally add a helper function to remove from the form data any values for child components that are under radios that did not get selected but were at some point filled in by the user. 