### PR TITLE
COP-10967: Fix for time input

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.7.3",
+    "@ukhomeoffice/cop-react-components": "1.7.4",
     "axios": "^0.21.1",
     "dayjs": "^1.11.0",
     "govuk-frontend": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -181,8 +181,7 @@ const getComponent = (config, wrap = true, fnOverride = undefined) => {
   }
 const component = getComponentByType(config);
   if (component && wrap && isEditable(config)) {
-    const attrs = cleanAttributes(config, ['fieldId', 'displayMenu']);
-    return wrapInFormGroup(attrs, component);
+    return wrapInFormGroup(config, component);
   }
   return component;
 };

--- a/src/utils/Component/getComponentTests/getComponent.time.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.time.test.js
@@ -1,0 +1,64 @@
+// Global imports
+import { fireEvent, getAllByTestId, render } from '@testing-library/react';
+
+// Local imports
+import { ComponentTypes } from '../../../models';
+import getComponent from '../getComponent';
+
+describe('utils.Component.get', () => {
+
+  it('should return an appropriately rendered time component', () => {
+    const ID = 'test-id';
+    const FIELD_ID = 'field-id';
+    const LABEL = 'label';
+    const ON_CHANGE_CALLS = [];
+    const ON_CHANGE = (e) => {
+      ON_CHANGE_CALLS.push(e.target);
+    };
+    const COMPONENT = {
+      type: ComponentTypes.TIME,
+      id: ID,
+      fieldId: FIELD_ID,
+      label: LABEL,
+      onChange: ON_CHANGE,
+      'data-testid': ID
+    };
+    const { container } = render(getComponent(COMPONENT));
+
+    const [ formGroup, timeInput ] = getAllByTestId(container, ID);
+    expect(formGroup.tagName).toEqual('DIV');
+    expect(formGroup.classList).toContain('govuk-form-group');
+    const label = formGroup.childNodes[0];
+    expect(label.innerHTML).toContain(LABEL);
+    expect(label.getAttribute('for')).toEqual(ID);
+    expect(timeInput.tagName).toEqual('DIV');
+    expect(timeInput.classList).toContain('govuk-date-input');
+    expect(timeInput.id).toEqual(ID);
+
+    let onChangeCalls = ON_CHANGE_CALLS.length;
+    const [hourItem, minuteItem] = timeInput.childNodes;
+    [
+      { id: 'hour', label: 'Hour', item: hourItem, value: '5', expectedValue: '5:' },
+      { id: 'minute', label: 'Minute', item: minuteItem, value: '11', expectedValue: '5:11' }
+    ].forEach(part => {
+      expect(part.item.tagName).toEqual('DIV');
+      expect(part.item.classList).toContain('govuk-date-input__item');
+      const [label, input] = part.item.childNodes;
+      expect(label.tagName).toEqual('LABEL');
+      expect(label.classList).toContain('govuk-label');
+      expect(label.textContent).toEqual(part.label);
+      expect(input.tagName).toEqual('INPUT');
+      expect(input.id).toEqual(`${ID}-${part.id}`);
+
+      // Put something in the input and make sure it fires.
+      fireEvent.change(input, { target: { name: `${FIELD_ID}-${part.id}`, value: part.value }});
+      onChangeCalls++;
+      expect(ON_CHANGE_CALLS.length).toEqual(onChangeCalls);
+      expect(ON_CHANGE_CALLS[onChangeCalls - 1]).toMatchObject({
+        name: FIELD_ID,
+        value: part.expectedValue
+      });
+    });
+  });
+
+});

--- a/src/utils/Component/wrapInFormGroup.js
+++ b/src/utils/Component/wrapInFormGroup.js
@@ -1,11 +1,17 @@
 // Global imports
-import React from 'react';
 import { FormGroup } from '@ukhomeoffice/cop-react-components';
+import React from 'react';
 
-const wrapInFormGroup = (config, children) => (
-  <FormGroup {...config} onChange={null}>
-    {children}
-  </FormGroup>
-);
+// Local imports
+import cleanAttributes from './cleanAttributes';
+
+const wrapInFormGroup = (config, children) => {
+  const attrs = cleanAttributes(config, ['fieldId', 'displayMenu']);
+  return (
+    <FormGroup {...attrs} onChange={null}>
+      {children}
+    </FormGroup>
+  )
+};
 
 export default wrapInFormGroup;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,14 +4242,15 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.7.3":
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.7.3.tgz#5e67af84cf9052dc1e694ea7655b2305b33d32fe"
-  integrity sha512-sCeWCH0VYhaI7zOf/TE5NdsKdE9BmsBQDAfnt+irpKgWsi/GhvbV12GkTHhUUoCTJv4p/RlIzgPuDQcHLDu6Iw==
+"@ukhomeoffice/cop-react-components@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.7.4.tgz#828b6175fd778381801356f6b617089144f4111d"
+  integrity sha512-91YWQAZOBvR88Jz0Uwd9DiXBMZNK2Nk815YnL7jzLZ0dOBgP5T9a1cI4DDh0E+by/wbnJhgvdHOQS4F9jl33oA==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"
     html-react-parser "^0.10.5"
+    react-select "^3.2.0"
     web-vitals "^1.0.1"
 
 "@webassemblyjs/ast@1.9.0":


### PR DESCRIPTION
### Description
Using version `"1.7.4"` of the component library, which includes the fixed `<TimeInput />` component. Also added some unit tests for the time input.

https://support.cop.homeoffice.gov.uk/browse/COP-10967

### To test
This is the broken behaviour, so make sure it's no longer happening in the Form Renderer Storybook:
1. Set up the JSON to have a time field;
2. Set up the initial data to have a valid value for that time field;
3. Switch to the Preview tab and you'll see the value appropriately showing in the time field;
4. Go back to the initial data and change to another valid value for the time field;
5. Switch back to the Preview tab and you'll now see the value in the time field flicking between the old and new values.