### PR TITLE
Fix option to have strings between radios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/FormComponent/FormComponent.jsx
+++ b/src/components/FormComponent/FormComponent.jsx
@@ -99,7 +99,9 @@ FormComponent.propTypes = {
     label: PropTypes.string,
     hint: PropTypes.string,
     data: PropTypes.shape({
-      options: PropTypes.arrayOf(PropTypes.object),
+      options: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+      ),
       url: PropTypes.string
     })
   }).isRequired,

--- a/src/utils/Data/getOptions.js
+++ b/src/utils/Data/getOptions.js
@@ -1,11 +1,16 @@
 import { Utils } from '@ukhomeoffice/cop-react-components';
 
 const interpolateOptions = (config, options) => {
-  return options.map(opt => ({
-    ...opt,
-    value: Utils.interpolateString(opt.value, config.formData),
-    label: Utils.interpolateString(opt.label, config.formData)
-  }));
+  return options.map((opt) => {
+    if (typeof opt === 'string') {
+      return opt;
+    }
+    return {
+      ...opt,
+      value: Utils.interpolateString(opt.value, config.formData),
+      label: Utils.interpolateString(opt.label, config.formData),
+    };
+  });
 };
 
 const getOptions = (config, callback) => {


### PR DESCRIPTION
Radio buttons have the option to have strings like 'or' between them, this is a fix to make them work again