### PR TITLE
CO-2173: warning text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.7.4",
+    "@ukhomeoffice/cop-react-components": "1.8.0",
     "axios": "^0.21.1",
     "dayjs": "^1.11.0",
     "govuk-frontend": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.2.7",
+  "version": "3.3.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/docs/ComponentExamples.stories.mdx
+++ b/src/docs/ComponentExamples.stories.mdx
@@ -237,6 +237,6 @@ and <Link href="/?path=/docs/f-json-component--page#fieldid--string">fieldId</Li
 ```json
 {
   "type":    "warning",
-  "content": "WarningYou can be fined up to £5,000 if you do not register."
+  "content": "You can be fined up to £5,000 if you do not register."
 }
 ```

--- a/src/docs/ComponentExamples.stories.mdx
+++ b/src/docs/ComponentExamples.stories.mdx
@@ -227,3 +227,16 @@ Use the time component when you want users to input a time.
   "required": true
 }
 ```
+
+## `inset-text`
+Use the warning text component to display a warning to the user, for example:
+
+Note that <Link href="/?path=/docs/f-json-component--page#id--string">id</Link> 
+and <Link href="/?path=/docs/f-json-component--page#fieldid--string">fieldId</Link> are not applicable for this type.
+
+```json
+{
+  "type":    "warning-text",
+  "content": "WarningYou can be fined up to £5,000 if you do not register."
+}
+```

--- a/src/docs/ComponentExamples.stories.mdx
+++ b/src/docs/ComponentExamples.stories.mdx
@@ -228,7 +228,7 @@ Use the time component when you want users to input a time.
 }
 ```
 
-## `inset-text`
+## `warning`
 Use the warning text component to display a warning to the user, for example:
 
 Note that <Link href="/?path=/docs/f-json-component--page#id--string">id</Link> 
@@ -236,7 +236,7 @@ and <Link href="/?path=/docs/f-json-component--page#fieldid--string">fieldId</Li
 
 ```json
 {
-  "type":    "warning-text",
+  "type":    "warning",
   "content": "WarningYou can be fined up to £5,000 if you do not register."
 }
 ```

--- a/src/docs/ComponentTypes.stories.mdx
+++ b/src/docs/ComponentTypes.stories.mdx
@@ -62,6 +62,6 @@ See <Link href="/?path=/docs/f-examples-component--page#date">example</Link>.
 Enter a time.
 See <Link href="/?path=/docs/f-examples-component--page#time">example</Link>.
 
-## `warning-text`
+## `warning`
 Display a warning to the user.
-See <Link href="/?path=/docs/f-examples-component--page#warning-text">example</Link>.
+See <Link href="/?path=/docs/f-examples-component--page#warning">example</Link>.

--- a/src/docs/ComponentTypes.stories.mdx
+++ b/src/docs/ComponentTypes.stories.mdx
@@ -61,3 +61,7 @@ See <Link href="/?path=/docs/f-examples-component--page#date">example</Link>.
 ## `time`
 Enter a time.
 See <Link href="/?path=/docs/f-examples-component--page#time">example</Link>.
+
+## `warning-text`
+Display a warning to the user.
+See <Link href="/?path=/docs/f-examples-component--page#warning-text">example</Link>.

--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -13,6 +13,7 @@ const TYPE_RADIOS = 'radios';
 const TYPE_TEXT = 'text';
 const TYPE_TEXT_AREA = 'textarea';
 const TYPE_TIME = 'time'
+const TYPE_WARNINGTEXT = 'warning-text'
 
 const ComponentTypes = {
   AUTOCOMPLETE: TYPE_AUTOCOMPLETE,
@@ -29,7 +30,8 @@ const ComponentTypes = {
   RADIOS: TYPE_RADIOS,
   TEXT: TYPE_TEXT,
   TEXT_AREA: TYPE_TEXT_AREA,
-  TIME: TYPE_TIME
+  TIME: TYPE_TIME,
+  WARNING_TEXT: TYPE_WARNINGTEXT
 };
 
 export default ComponentTypes;

--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -13,7 +13,7 @@ const TYPE_RADIOS = 'radios';
 const TYPE_TEXT = 'text';
 const TYPE_TEXT_AREA = 'textarea';
 const TYPE_TIME = 'time'
-const TYPE_WARNINGTEXT = 'warning-text'
+const TYPE_WARNING = 'warning'
 
 const ComponentTypes = {
   AUTOCOMPLETE: TYPE_AUTOCOMPLETE,
@@ -31,7 +31,7 @@ const ComponentTypes = {
   TEXT: TYPE_TEXT,
   TEXT_AREA: TYPE_TEXT_AREA,
   TIME: TYPE_TIME,
-  WARNING_TEXT: TYPE_WARNINGTEXT
+  WARNING: TYPE_WARNING
 };
 
 export default ComponentTypes;

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -11,6 +11,7 @@ import {
   TextArea,
   TextInput,
   TimeInput,
+  WarningText
 } from '@ukhomeoffice/cop-react-components';
 import React from 'react';
 
@@ -99,6 +100,11 @@ const getTime = (config) => {
   return <TimeInput {...attrs} />;
 };
 
+const getWarningText = (config) => {
+  const attrs = cleanAttributes(config);
+  return <WarningText {...attrs}>{config.content}</WarningText>;
+};
+
 const getComponentByType = (config) => {
   switch (config.type) {
     case ComponentTypes.HTML:
@@ -125,6 +131,8 @@ const getComponentByType = (config) => {
       return getTime(config);
     case ComponentTypes.FILE:
       return getFileUpload(config);
+    case ComponentTypes.WARNING_TEXT:
+      return getWarningText(config);
     default: {
       return null;
     }

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -131,7 +131,7 @@ const getComponentByType = (config) => {
       return getTime(config);
     case ComponentTypes.FILE:
       return getFileUpload(config);
-    case ComponentTypes.WARNING_TEXT:
+    case ComponentTypes.WARNING:
       return getWarningText(config);
     default: {
       return null;

--- a/src/utils/Component/getComponentTests/getComponent.warningText.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.warningText.test.js
@@ -7,7 +7,7 @@ import getComponent from '../getComponent';
 
 describe('utils.Component.get', () => {
 
-  it('should return an appropriately rendered warning-tet component', () => {
+  it('should return an appropriately rendered warning-text component', () => {
     const ID = 'test-id';
     const CONTENT = 'Warning Text';
     const COMPONENT = { type: ComponentTypes.WARNING_TEXT, content: CONTENT, 'data-testid': ID };

--- a/src/utils/Component/getComponentTests/getComponent.warningText.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.warningText.test.js
@@ -1,0 +1,22 @@
+// Global imports
+import { getByTestId, render } from '@testing-library/react';
+
+// Local imports
+import { ComponentTypes } from '../../../models';
+import getComponent from '../getComponent';
+
+describe('utils.Component.get', () => {
+
+  it('should return an appropriately rendered warning-tet component', () => {
+    const ID = 'test-id';
+    const CONTENT = 'Warning Text';
+    const COMPONENT = { type: ComponentTypes.WARNING_TEXT, content: CONTENT, 'data-testid': ID };
+    const { container } = render(getComponent(COMPONENT));
+
+    const warningText = getByTestId(container, ID);
+    expect(warningText.innerHTML).toContain(CONTENT);
+    expect(warningText.tagName).toEqual('DIV');
+    expect(warningText.classList).toContain('govuk-warning-text');
+  });
+
+});

--- a/src/utils/Component/getComponentTests/getComponent.warningText.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.warningText.test.js
@@ -10,7 +10,7 @@ describe('utils.Component.get', () => {
   it('should return an appropriately rendered warning-text component', () => {
     const ID = 'test-id';
     const CONTENT = 'Warning Text';
-    const COMPONENT = { type: ComponentTypes.WARNING_TEXT, content: CONTENT, 'data-testid': ID };
+    const COMPONENT = { type: ComponentTypes.WARNING, content: CONTENT, 'data-testid': ID };
     const { container } = render(getComponent(COMPONENT));
 
     const warningText = getByTestId(container, ID);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.7.4":
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.7.4.tgz#828b6175fd778381801356f6b617089144f4111d"
-  integrity sha512-91YWQAZOBvR88Jz0Uwd9DiXBMZNK2Nk815YnL7jzLZ0dOBgP5T9a1cI4DDh0E+by/wbnJhgvdHOQS4F9jl33oA==
+"@ukhomeoffice/cop-react-components@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.8.0.tgz#9a23f44936b3a5377f1467b5c0b9feffe4f77581"
+  integrity sha512-Uu3VzNzE8wENvxcFbLA6HfZIGQUeIciTD0+JIKqKpTFaqXJ4OXqNBrxyL9wtVqlyTDV8nsQ7zr1ROSkrPb03yg==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"


### PR DESCRIPTION
Description: 

Addition of new component "warning" to display a warning message to the user. Cop components dependency has been updated to include new component and storybook documentation added.

To Test: 
1. Create a new form with a component of type "warning-text".
2. Verify that the component is correctly displayed and is in line with GDS. (https://design-system.service.gov.uk/components/warning-text/)
3. Verify that "content" provided is accurately displayed inside the warning text component.

Example JSON

{
  "type": "warning",
  "content": "Your warning message here"
}

Jira Ticket - https://support.cop.homeoffice.gov.uk/browse/CO-2173