### PR TITLE
COP-10220: Improve support for refdata options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/hooks/useRefData.js
+++ b/src/hooks/useRefData.js
@@ -1,4 +1,5 @@
 // Global imports
+import { Utils as HOUtils } from '@ukhomeoffice/cop-react-components';
 import { useEffect, useState } from 'react';
 
 // Local imports
@@ -11,7 +12,7 @@ export const STATUS_COMPLETE = 'complete';
 const getRefDataUrl = (component) => {
   const data = component.data;
   if (data && !data.options) {
-    return data.url;
+    return HOUtils.interpolateString(data.url, component.formData);
   }
   return undefined;
 };
@@ -24,12 +25,12 @@ const useRefData = (component) => {
   useEffect(() => {
     if (!url) {
       if (component.data && component.data.options) {
-        setData(Data.refData.toOptions(component.data.options));
+        setData(Data.refData.toOptions(component.data.options, component.item));
       }
       setStatus(STATUS_COMPLETE);
     } else if (_status === STATUS_FETCHED) {
       if (_data) {
-        setData(Data.refData.toOptions(_data.data));
+        setData(Data.refData.toOptions(_data.data, component.item));
       }
       setStatus(STATUS_COMPLETE);
     } else if (_status === STATUS_ERROR) {

--- a/src/hooks/useRefData.test.js
+++ b/src/hooks/useRefData.test.js
@@ -18,7 +18,7 @@ const TestComponent = ({ component }) => {
   return (
     <ul>
       {data.map((item, index) => (
-        <li key={index} id={item.id}>{item.name}</li>
+        <li key={index} id={item.value}>{item.label}</li>
       ))}
     </ul>
   );
@@ -29,9 +29,9 @@ describe('hooks', () => {
   describe('useRefData', () => {
 
     const ABC = [
-      { id: 'a', name: 'Alpha' },
-      { id: 'b', name: 'Beta' },
-      { id: 'c', name: 'Charlie' }
+      { id: 'a', name: 'Alpha', specialName: 'Alpha Centauri', guid: '123456' },
+      { id: 'b', name: 'Beta', specialName: 'Beta Carotene', guid: '234567' },
+      { id: 'c', name: 'Charlie', specialName: 'Charlie Chaplin', guid: '345678' }
     ];
     const mockAxios = new MockAdapter(axios);
     let container = null;
@@ -108,6 +108,26 @@ describe('hooks', () => {
 
       await act(() => sleep(100));
       expect(container.textContent).toEqual(STATUS_COMPLETE);
+    });
+
+    it('can handle a component with a custom item structure', async () => {
+      const COMPONENT = {
+        id: 'component',
+        data: { options: ABC },
+        item: { value: 'guid', label: 'specialName' }
+      };
+      act(() => {
+        renderDomWithValidation(<TestComponent component={COMPONENT} />, container);
+      });
+
+      expect(container.childNodes.length).toEqual(1);
+      const ul = container.childNodes[0];
+      expect(ul.tagName).toEqual('UL');
+      expect(ul.childNodes.length).toEqual(ABC.length);
+      ul.childNodes.forEach((li, index) => {
+        expect(li.id).toEqual(ABC[index].guid);
+        expect(li.textContent).toEqual(ABC[index].specialName);
+      });
     });
 
   });

--- a/src/utils/Data/refDataToOptions.js
+++ b/src/utils/Data/refDataToOptions.js
@@ -1,9 +1,20 @@
+const getValueAndLabel = (opt, itemStructure) => {
+  let value = opt.value || opt.id;
+  let label = opt.label || opt.name;
+  if (itemStructure) {
+    value = opt[itemStructure.value] || value;
+    label = opt[itemStructure.label] || label;
+  }
+  return { value: value?.toString(), label };
+};
+
 /**
  * Converts ref data items to options.
  * @param {Array} refDataItems An array of ref data items.
+ * @param {Object} itemStructure The structure of the item.
  * @returns An array of options.
  */
-const refDataToOptions = (refDataItems) => {
+const refDataToOptions = (refDataItems, itemStructure) => {
   if (Array.isArray(refDataItems)) {
     return refDataItems.map((opt) => {
       if (typeof opt === 'string') {
@@ -11,8 +22,7 @@ const refDataToOptions = (refDataItems) => {
       }
       return {
         ...opt,
-        value: opt.id || opt.value,
-        label: opt.name || opt.label,
+        ...getValueAndLabel(opt, itemStructure)
       };
     });
   }

--- a/src/utils/Data/refDataToOptions.test.js
+++ b/src/utils/Data/refDataToOptions.test.js
@@ -69,6 +69,34 @@ describe('utils', () => {
         ]);
       });
 
+      it('can handle refData with custom value and label properties', () => {
+        const REF_DATA = [
+          { id: 1, displayName: 'Alpha' },
+          { id: 2, displayName: 'Bravo' },
+          { id: 3, displayName: 'Charlie' }
+        ];
+        const ITEM_STRUCTURE = { value: 'id', label: 'displayName' };
+        expect(refDataToOptions(REF_DATA, ITEM_STRUCTURE)).toEqual([
+          { id: 1, displayName: 'Alpha', value: '1', label: 'Alpha' },
+          { id: 2, displayName: 'Bravo', value: '2', label: 'Bravo' },
+          { id: 3, displayName: 'Charlie', value: '3', label: 'Charlie' }
+        ]);
+      });
+
+      it('can handle refData with missing custom value and label properties', () => {
+        const REF_DATA = [
+          { id: 1, name: 'Alpha' },
+          { id: 2, name: 'Bravo', displayName: 'Bravo Zulu' },
+          { id: 3, objId: 'chaz', name: 'Charlie' }
+        ];
+        const ITEM_STRUCTURE = { value: 'objId', label: 'displayName' };
+        expect(refDataToOptions(REF_DATA, ITEM_STRUCTURE)).toEqual([
+          { id: 1, name: 'Alpha', value: '1', label: 'Alpha' },
+          { id: 2, name: 'Bravo', displayName: 'Bravo Zulu', value: '2', label: 'Bravo Zulu' },
+          { id: 3, objId: 'chaz', name: 'Charlie', value: 'chaz', label: 'Charlie' }
+        ]);
+      });
+
     });
 
   });

--- a/src/utils/Data/setupRefDataUrlForComponent.js
+++ b/src/utils/Data/setupRefDataUrlForComponent.js
@@ -1,15 +1,38 @@
 // Global imports
 import { Utils as HOUtils } from '@ukhomeoffice/cop-react-components';
+import { ComponentTypes } from '../../models';
+
+const setupRefDataForContainer = (container, data) => ({
+  ...container,
+  components: setupRefDataUrlForComponents(container.components, data)
+});
+
+const setupRefDataForCollection = (collection, data) => ({
+  ...collection,
+  item: setupRefDataUrlForComponents(collection.item, data)
+});
+
+const setupRefDataUrlForComponents = (components, data) => {
+  return components.map(component => setupRefDataUrlForComponent(component, data));
+};
 
 const setupRefDataUrlForComponent = (component, data) => {
-  if (component && component.data && component.data.url) {
-    return {
-      ...component,
-      data: {
-        ...component.data,
-        url: HOUtils.interpolateString(component.data.url, data)
-      }
-    };
+  if (component) {
+    if (component.type === ComponentTypes.CONTAINER) {
+      return setupRefDataForContainer(component, data);
+    }
+    if (component.type === ComponentTypes.COLLECTION) {
+      return setupRefDataForCollection(component, data);
+    }
+    if (component.data && component.data.url) {
+      return {
+        ...component,
+        data: {
+          ...component.data,
+          url: HOUtils.interpolateString(component.data.url, data)
+        }
+      };
+    }
   }
   return component;
 };

--- a/src/utils/Data/setupRefDataUrlForComponent.test.js
+++ b/src/utils/Data/setupRefDataUrlForComponent.test.js
@@ -1,4 +1,5 @@
 // Local imports
+import { ComponentTypes } from '../../models';
 import setupRefDataUrlForComponent from './setupRefDataUrlForComponent';
 
 describe('utils', () => {
@@ -34,7 +35,7 @@ describe('utils', () => {
         expect(setupRefDataUrlForComponent(COMPONENT, DATA)).toEqual(COMPONENT);
       });
 
-      it('should appropriately updates the component URL', () => {
+      it('should appropriately update the component URL', () => {
         const COMPONENT = {
           id: 'component',
           // eslint-disable-next-line no-template-curly-in-string
@@ -72,6 +73,56 @@ describe('utils', () => {
           data: {
             url: '/v1/teams'
           }
+        });
+      });
+
+      it('should appropriately update the component URLs within a container', () => {
+        const COMPONENT = {
+          id: 'component',
+          // eslint-disable-next-line no-template-curly-in-string
+          data: { url: '${urls.refData}/v1/teams' }
+        };
+        const CONTAINER = {
+          id: 'container',
+          type: ComponentTypes.CONTAINER,
+          components: [ COMPONENT ]
+        };
+        expect(setupRefDataUrlForComponent(CONTAINER, DATA)).toEqual({
+          id: CONTAINER.id,
+          type: CONTAINER.type,
+          components: [
+            {
+              id: COMPONENT.id,
+              data: {
+                url: `${DATA.urls.refData}/v1/teams`
+              }
+            }
+          ]
+        });
+      });
+
+      it('should appropriately update the component URLs within a collection', () => {
+        const COMPONENT = {
+          id: 'component',
+          // eslint-disable-next-line no-template-curly-in-string
+          data: { url: '${urls.refData}/v1/teams' }
+        };
+        const COLLECTION = {
+          id: 'container',
+          type: ComponentTypes.COLLECTION,
+          item: [ COMPONENT ]
+        };
+        expect(setupRefDataUrlForComponent(COLLECTION, DATA)).toEqual({
+          id: COLLECTION.id,
+          type: COLLECTION.type,
+          item: [
+            {
+              id: COMPONENT.id,
+              data: {
+                url: `${DATA.urls.refData}/v1/teams`
+              }
+            }
+          ]
         });
       });
 

--- a/src/utils/FormPage/getFormPage.js
+++ b/src/utils/FormPage/getFormPage.js
@@ -27,7 +27,7 @@ const getFormPage = (pageOptions, formComponents, formData) => {
       ret = { ...componentOptions };
     }
 
-    return formData && formData.urls ? Data.refData.setupUrl(ret, formData) : ret;
+    return formData ? Data.refData.setupUrl(ret, formData) : ret;
   });
   const actions = getPageActions(pageOptions);
   return Container.setup({

--- a/src/utils/FormPage/getFormPage.test.js
+++ b/src/utils/FormPage/getFormPage.test.js
@@ -127,7 +127,7 @@ describe('utils', () => {
             { ...PAGE.components[1], full_path: PAGE.components[1].fieldId },
             { type: 'html', tagName: 'p', content: PAGE.components[2] },
             // eslint-disable-next-line no-template-curly-in-string
-            { use: 'c', ...C, cya_label: C.label, full_path: C.fieldId, data: { url: '${urls.refData}/v3/charlies' } }
+            { use: 'c', ...C, cya_label: C.label, full_path: C.fieldId, data: { url: '/v3/charlies' } }
           ],
           formData: {}
         });


### PR DESCRIPTION
### Description
Added support for a custom item structure for reference data options that are returned, along with support for numeric identifiers that should be used as option values.

https://support.cop.homeoffice.gov.uk/browse/COP-10220

### To test
Covered by accompanying unit tests, but this will also be visible when setting up a form with differently structured reference data, such as the TIS ([COP-10220](https://support.cop.homeoffice.gov.uk/browse/COP-10220)).