### PR TITLE
CO-2174: details component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.3.4",
+  "version": "3.4.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/CheckYourAnswers/CheckYourAnswers.jsx
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.jsx
@@ -124,7 +124,7 @@ const CheckYourAnswers = ({
           return (
             <Fragment key={pageIndex}>
               {(!hide_page_titles && page.title && !isGroup(page.id))   && (
-                <MediumHeading>{page.title}</MediumHeading>
+                <MediumHeading>{Utils.interpolateString(page.title, page.formData)}</MediumHeading>
               )}
               {(isGroup(page.id)) && (
                 <div className='group-title'>

--- a/src/components/CheckYourAnswers/CheckYourAnswers.test.js
+++ b/src/components/CheckYourAnswers/CheckYourAnswers.test.js
@@ -233,6 +233,62 @@ describe('components', () => {
       expect(changeButton.textContent).toEqual('Change names');
     });
 
+    it('should show page components corrently with interpolated title and cya_label, if label is missing', async () => {
+      const _PAGES = [ ...USER_PROFILE.pages ];
+      // eslint-disable-next-line no-template-curly-in-string
+      _PAGES[0] = { ..._PAGES[0], title: 'Alpha ID: ${businessKey}'}
+      const _COMPONENTS = [ ...USER_PROFILE.components ];
+      _COMPONENTS[0] = { ..._COMPONENTS[0], 
+        label: undefined,
+        required: true,
+        // eslint-disable-next-line no-template-curly-in-string
+        cya_label: "Text ${currentUser.familyName}"
+      };
+      const T_PAGES = Utils.FormPage.getAll(_PAGES, _COMPONENTS, DATA );
+      await act(async () => {
+        renderDomWithValidation(
+          <CheckYourAnswers pages={T_PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />,
+          container
+        );
+      });
+      const cya = checkCYA(container);
+      const [, cyaTitle, cyaChildNode] = cya.childNodes;
+      expect(cyaTitle.textContent).toEqual('Alpha ID: 123456789');
+      const names = cyaChildNode.childNodes[0];
+      expect(names.tagName).toEqual('DL');
+      expect(names.classList).toContain(`govuk-!-margin-bottom-${DEFAULT_MARGIN_BOTTOM}`);
+      const [firstName, surname] = names.childNodes;
+      const [label, value] = firstName.childNodes;
+      expect(label.textContent).toEqual('Text Smith');
+      checkRow(surname, 'Last name', 'Smith', false);
+    });
+
+    it('should show page components corrently with no label, if label and cya_label are missing', async () => {
+      const _PAGES = [ ...USER_PROFILE.pages ];
+      const _COMPONENTS = [ ...USER_PROFILE.components ];
+      _COMPONENTS[0] = { ..._COMPONENTS[0], 
+        label: undefined,
+        required: true,
+        cya_label: undefined
+      };
+      const T_PAGES = Utils.FormPage.getAll(_PAGES, _COMPONENTS, { ...DATA });
+      await act(async () => {
+        renderDomWithValidation(
+          <CheckYourAnswers pages={T_PAGES} onRowAction={ON_ROW_ACTION} onAction={ON_ACTION} />,
+          container
+        );
+      });
+      const cya = checkCYA(container);
+      const [, cyaChildNode] = cya.childNodes;
+      const names = cyaChildNode.childNodes[0];
+      expect(names.tagName).toEqual('DL');
+      expect(names.classList).toContain(`govuk-!-margin-bottom-${DEFAULT_MARGIN_BOTTOM}`);
+      const [firstName, surname] = names.childNodes;
+      const [label, value] = firstName.childNodes;
+      expect(label.textContent).toEqual("");
+      checkRow(surname, 'Last name', 'Smith', false);
+    });
+
   });
 
 });

--- a/src/components/FormComponent/FormComponent.jsx
+++ b/src/components/FormComponent/FormComponent.jsx
@@ -86,6 +86,7 @@ const FormComponent = ({
     label: Utils.interpolateString(component.label, formData),
     content: Utils.interpolateString(component.content, formData),
     hint: Utils.interpolateString(component.hint, formData),
+    cya_label: Utils.interpolateString(component.cya_label, formData),
     options,
     value: value || Utils.Component.defaultValue(component),
     onChange: onComponentChangeExtended,

--- a/src/components/FormComponent/FormComponent.test.js
+++ b/src/components/FormComponent/FormComponent.test.js
@@ -98,6 +98,37 @@ describe('components', () => {
       expect(p.textContent).toEqual(COMPONENT.content);
     });
 
+    it('should render a text component appropriately with interpolated label', async () => {
+      const ID = 'component';
+      const VALUE = 'Text value';
+      // eslint-disable-next-line no-template-curly-in-string
+      const COMPONENT = { id: ID, fieldId: ID, type: 'text', label: '${text} Text component', cya_label: '${text} Text component', hint: 'Text hint' };
+      const DATA = { text: 'Interpolated'}
+      const ON_CHANGE = () => {};
+      const { container } = renderWithValidation(
+        <FormComponent data-testid={ID} component={COMPONENT} value={VALUE} onChange={ON_CHANGE} formData={DATA} />
+      );
+
+      // text components are wrapper in a FormGroup by default.
+      const formGroup = container.childNodes[0];
+      expect(formGroup.tagName).toEqual('DIV');
+      expect(formGroup.classList).toContain('govuk-form-group');
+      const label = formGroup.childNodes[0];
+      expect(label.tagName).toEqual('LABEL');
+      expect(label.classList).toContain('govuk-label');
+      expect(label.textContent).toEqual('Interpolated Text component (optional)');
+      expect(label.getAttribute('for')).toEqual(ID);
+      const hint = formGroup.childNodes[1];
+      expect(hint.tagName).toEqual('SPAN');
+      expect(hint.classList).toContain('govuk-hint');
+      expect(hint.textContent).toEqual(COMPONENT.hint);
+      const input = formGroup.childNodes[2];
+      expect(input.tagName).toEqual('INPUT');
+      expect(input.classList).toContain('govuk-input');
+      expect(input.id).toEqual(ID);
+      expect(input.value).toEqual(VALUE);
+    });
+
   });
 
 });

--- a/src/docs/ComponentExamples.stories.mdx
+++ b/src/docs/ComponentExamples.stories.mdx
@@ -30,6 +30,41 @@ to be able to search through and select one from.
 }
 ```
 
+## `date`
+Use the date component when you want users to input a date.
+
+```json
+{
+  "id": "startDate",
+  "fieldId": "startDate",
+  "label": "Please enter the start date",
+  "type": "date",
+  "required": true
+}
+```
+
+## `details`
+Use the details component when you want to display additional information to the user that may not be neccessary for all users.
+
+```json
+{
+  "id": "nationality",
+  "summary": "Help with nationality",
+  "content": "We need to know your nationality so we can work out which elections you're entitled to vote in. If you cannot provide your nationality, you'll have to send copies of identity documents through the post.",
+  "type": "details"
+}
+```
+You can pass html in 'content' for custom mark up.
+
+```json
+{
+  "id": "nationality",
+  "summary": "Help with nationality",
+  "content": "<p>First line of text</p><ol><li>one</li><li>two</li></ol><p>Second line of text</p>",
+  "type": "details"
+}
+```
+
 ## `email`
 Use the email component when you want users to enter an email address.
 
@@ -199,19 +234,6 @@ Use the textarea component when you want users to enter multiple lines of text.
   "fieldId": "additionalInfo",
   "label": "Please add additional information",
   "type": "textarea"
-}
-```
-
-## `date`
-Use the date component when you want users to input a date.
-
-```json
-{
-  "id": "startDate",
-  "fieldId": "startDate",
-  "label": "Please enter the start date",
-  "type": "date",
-  "required": true
 }
 ```
 

--- a/src/docs/ComponentTypes.stories.mdx
+++ b/src/docs/ComponentTypes.stories.mdx
@@ -13,6 +13,14 @@ Also see <Link href="/?path=/docs/f-editable-components">editable components</Li
 Search for and select an item from a (usually large) set of options.
 See <Link href="/?path=/docs/f-examples-component--page#autocomplete">example</Link>.
 
+## `date`
+Enter a date.
+See <Link href="/?path=/docs/f-examples-component--page#date">example</Link>.
+
+## `details`
+Use the details component to display information which is hidden until the summary is clicked.
+See <Link href="/?path=/docs/f-examples-component--page#details">example</Link>.
+
 ## `email`
 Enter an email address.
 See <Link href="/?path=/docs/f-examples-component--page#email">example</Link>.
@@ -53,10 +61,6 @@ See <Link href="/?path=/docs/f-examples-component--page#text">example</Link>.
 ## `textarea`
 Enter multiple lines of free text.
 See <Link href="/?path=/docs/f-examples-component--page#textarea">example</Link>.
-
-## `date`
-Enter a date.
-See <Link href="/?path=/docs/f-examples-component--page#date">example</Link>.
 
 ## `time`
 Enter a time.

--- a/src/models/ComponentTypes.js
+++ b/src/models/ComponentTypes.js
@@ -3,6 +3,7 @@ const TYPE_CHECKBOXES = 'checkboxes';
 const TYPE_COLLECTION = 'collection';
 const TYPE_CONTAINER = 'container';
 const TYPE_DATE = 'date';
+const TYPE_DETAILS = 'details';
 const TYPE_EMAIL = 'email';
 const TYPE_FILE = 'file';
 const TYPE_HEADING = 'heading';
@@ -21,6 +22,7 @@ const ComponentTypes = {
   COLLECTION: TYPE_COLLECTION,
   CONTAINER: TYPE_CONTAINER,
   DATE: TYPE_DATE,
+  DETAILS: TYPE_DETAILS,
   EMAIL: TYPE_EMAIL,
   FILE: TYPE_FILE,
   HEADING: TYPE_HEADING,

--- a/src/utils/CheckYourAnswers/getCYARow.js
+++ b/src/utils/CheckYourAnswers/getCYARow.js
@@ -1,3 +1,6 @@
+// Global imports
+import { Utils } from '@ukhomeoffice/cop-react-components';
+
 // Local imports
 import Component from '../Component';
 import getCYAAction from './getCYAAction';
@@ -23,7 +26,7 @@ const getCYARow = (page, component, onAction) => {
     id: component.id,
     fieldId: component.fieldId,
     full_path: component.full_path,
-    key: component.label || component.cya_label,
+    key: Utils.interpolateString(component.label || component.cya_label, page.formData),
     required: component.required,
     component: Component.editable(component) ? component : undefined,
     value: value || '',

--- a/src/utils/CheckYourAnswers/getCYARow.test.js
+++ b/src/utils/CheckYourAnswers/getCYARow.test.js
@@ -133,6 +133,38 @@ describe('utils', () => {
         expect(ROW.component.data.options[0].nested[0].value).toBeUndefined();
       });
 
+      it('should get an appropriate row for a readonly text component with no value and interpolated label', () => {
+        const PAGE = { id: 'page', formData: { text: 'Smith' } };
+        // eslint-disable-next-line no-template-curly-in-string
+        const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', label: 'Alpha ${text}' };
+        const ON_ACTION = () => {};
+        expect(getCYARow(PAGE, COMPONENT, ON_ACTION)).toEqual({
+          pageId: PAGE.id,
+          id: COMPONENT.id,
+          fieldId: COMPONENT.fieldId,
+          key: 'Alpha Smith',
+          value: '',
+          component: COMPONENT,
+          action: null
+        });
+      });
+
+      it('should use the interolated cya_label where there is no label', () => {
+        const PAGE = { id: 'page', formData: { a: 'Bravo' } };
+        // eslint-disable-next-line no-template-curly-in-string
+        const COMPONENT = { type: 'text', readonly: true, id: 'a', fieldId: 'a', cya_label: 'CYA Alpha ${a}' };
+        const ON_ACTION = () => {};
+        const ROW = getCYARow(PAGE, COMPONENT, ON_ACTION);
+        expectObjectLike(ROW, {
+          pageId: PAGE.id,
+          fieldId: COMPONENT.fieldId,
+          key: 'CYA Alpha Bravo',
+          action: null,
+          component: COMPONENT,
+          value: 'Bravo'
+        });
+      });
+
     });
 
   });

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -53,8 +53,8 @@ const getDate = (config) => {
 
 const getDetails = (config) => {
   const attrs = cleanAttributes(config);
-  console.log(config)
-  return <Details {...attrs}>{config.content}</Details>
+  const html = getHTML(config)
+  return <Details {...attrs}>{html}</Details>
 }
 
 const getFileUpload = (config) => {

--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -3,6 +3,7 @@ import {
   Autocomplete,
   Checkboxes,
   DateInput,
+  Details,
   FileUpload,
   Heading,
   InsetText,
@@ -49,6 +50,12 @@ const getDate = (config) => {
   const attrs = cleanAttributes(config);
   return <DateInput {...attrs} />;
 };
+
+const getDetails = (config) => {
+  const attrs = cleanAttributes(config);
+  console.log(config)
+  return <Details {...attrs}>{config.content}</Details>
+}
 
 const getFileUpload = (config) => {
   const attrs = cleanAttributes(config);
@@ -133,6 +140,8 @@ const getComponentByType = (config) => {
       return getFileUpload(config);
     case ComponentTypes.WARNING:
       return getWarningText(config);
+    case ComponentTypes.DETAILS:
+      return getDetails(config);
     default: {
       return null;
     }

--- a/src/utils/Component/getComponentTests/getComponent.details.test.js
+++ b/src/utils/Component/getComponentTests/getComponent.details.test.js
@@ -1,0 +1,41 @@
+// Global imports
+import { render } from '@testing-library/react';
+
+// Local imports
+import { ComponentTypes } from '../../../models';
+import getComponent from '../getComponent';
+
+describe('utils.Component.get', () => {
+
+  it('should return a details component containing basic text', () => {
+    const ID = 'test-id';
+    const CONTENT = 'Details content';
+    const SUMMARY = 'Details Summary';
+    const COMPONENT = { type: ComponentTypes.DETAILS, content: CONTENT, summary: SUMMARY , 'data-testid': ID };
+    const { container } = render(getComponent(COMPONENT));
+
+    const details = container.querySelector('details');
+    expect(details.classList).toContain('hods-details');
+    expect(details.childNodes[0].textContent).toEqual(SUMMARY);
+    expect(details.childNodes[1].textContent).toEqual(CONTENT);
+  });
+
+  it('should return a details component containing multiple html components', () => {
+    const ID = 'test-id';
+    const CONTENT = '<p>this is the content</p><ol><li>one</li><li>two</li></ol><p>second section of content</p>';
+    const SUMMARY = 'Details Summary';
+    const COMPONENT = { type: ComponentTypes.DETAILS, content: CONTENT, summary: SUMMARY , 'data-testid': ID };
+    const { container } = render(getComponent(COMPONENT));
+
+    const details = container.querySelector('details');
+    expect(details.classList).toContain('hods-details');
+    expect(details.childNodes[1].childNodes[0].childNodes[0].textContent).toEqual('this is the content');
+    expect(details.childNodes[1].childNodes[0].childNodes[0].tagName).toEqual('P');
+    expect(details.childNodes[1].childNodes[0].childNodes[1].childNodes[0].textContent).toEqual('one');
+    expect(details.childNodes[1].childNodes[0].childNodes[1].childNodes[1].textContent).toEqual('two');
+    expect(details.childNodes[1].childNodes[0].childNodes[1].tagName).toEqual('OL');
+    expect(details.childNodes[1].childNodes[0].childNodes[2].textContent).toEqual('second section of content');
+    expect(details.childNodes[1].childNodes[0].childNodes[2].tagName).toEqual('P');
+  });
+
+});

--- a/src/utils/FormPage/useComponent.js
+++ b/src/utils/FormPage/useComponent.js
@@ -12,7 +12,7 @@ const useComponent = (toUse, formComponents) => {
     return {
       ...formComponent,
       ...toUse,
-      cya_label: formComponent.label,
+      cya_label: formComponent.label || formComponent.cya_label,
       fieldId
     };
   }

--- a/src/utils/FormPage/useComponent.test.js
+++ b/src/utils/FormPage/useComponent.test.js
@@ -10,7 +10,8 @@ describe('utils', () => {
       const FORM_COMPONENTS = [
         { id: 'a', fieldId: 'a', label: 'Alpha', type: 'text' },
         { id: 'b', fieldId: 'b', label: 'Bravo', type: 'text' },
-        { id: 'c', fieldId: 'c', label: 'Charlie', type: 'text' }
+        { id: 'c', fieldId: 'c', label: 'Charlie', type: 'text' },
+        { id: 'd', fieldId: 'd', cya_label: 'Delta', type: 'text' }
       ];
 
       it('should handle a null toUse configuration', () => {
@@ -19,7 +20,7 @@ describe('utils', () => {
       });
 
       it('should handle an unrecognised component reference', () => {
-        const TO_USE = { use: 'd', label: 'Delta' };
+        const TO_USE = { use: 'e', label: 'Echo' };
         expect(useComponent(TO_USE, FORM_COMPONENTS)).toEqual(TO_USE);
       });
 
@@ -51,6 +52,28 @@ describe('utils', () => {
           use: 'a',
           ...A,
           cya_label: A.label,
+          label: TO_USE.label
+        });
+      });
+
+      it('should allow the form component cya_label, if label is empty', () => {
+        const TO_USE = { use: 'd', label: '' };
+        const A = FORM_COMPONENTS[3];
+        expect(useComponent(TO_USE, FORM_COMPONENTS)).toEqual({
+          use: 'd',
+          ...A,
+          cya_label: A.cya_label,
+          label: TO_USE.label
+        });
+      });
+
+      it('should allow the form component cya_label, if label is not given', () => {
+        const TO_USE = { use: 'd' };
+        const A = FORM_COMPONENTS[3];
+        expect(useComponent(TO_USE, FORM_COMPONENTS)).toEqual({
+          use: 'd',
+          ...A,
+          cya_label: A.cya_label,
           label: TO_USE.label
         });
       });


### PR DESCRIPTION
Description:

Addition of new component "details" to display additional information to the user that may not be relevant to all users. Displays an initial "summary" which should describe what is in the "content" when the summary is clicked.

To Test:

Create a new form with a component of type "details".
Verify that the component is correctly displayed and is in line with GDS. (https://design-system.service.gov.uk/components/details/)
Verify that "content" provided is accurately displayed after clicking on the "summary" text.
Example JSON

{
"type": "details",
"summary": "Summary",
"content": "Additional information goes here"
}

Jira Ticket - https://support.cop.homeoffice.gov.uk/browse/CO-2174