### PR TITLE
CI-130 Added a fix for formData getting wiped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/FormPage/FormPage.jsx
+++ b/src/components/FormPage/FormPage.jsx
@@ -48,7 +48,7 @@ const FormPage = ({
         <FormComponent key={index}
           component={component}
           onChange={onPageChange}
-          value={page.formData[component.fieldId]}
+          value={page.formData[component.fieldId] || patch[component.fieldId]}
           formData={page.formData}
         />
       ))}

--- a/src/components/FormRenderer/FormRenderer.jsx
+++ b/src/components/FormRenderer/FormRenderer.jsx
@@ -164,6 +164,10 @@ const InternalFormRenderer = ({
 
   // Handle actions from pages.
   const onPageAction = (action, patch) => {
+    // Re-apply the patch to the page's formData.
+    // This should normally have no effect but will prevent issues 
+    // with validation if formData happens to have been wiped.
+    formState.page.formData = {...formState.page.formData, ...patch};
     // Check to see whether the action is able to proceed, which in
     // in the case of a submission will validate the fields in the page.
     if (helpers.canActionProceed(action, formState.page, validate.page)) {


### PR DESCRIPTION
This is a fix/workaround for anchor links in the `ErrorSummary` component wiping a pages `formData` when clicked on.

The suggested changes just reapply a pages `patch` data to its `formData` before validation. Values for components within the page are also now only taken from `formData` if no value exists for them in `patch`.
