### PR TITLE
EAB-691 Fixed clicking an ErrorSummary link wiping nested components

### DIFF
--- a/src/components/FormPage/FormPage.jsx
+++ b/src/components/FormPage/FormPage.jsx
@@ -49,7 +49,7 @@ const FormPage = ({
           component={component}
           onChange={onPageChange}
           value={page.formData[component.fieldId] || patch[component.fieldId]}
-          formData={page.formData}
+          formData={{...page.formData, ...patch}}
         />
       ))}
       <PageActions actions={page.actions} onAction={(action) => onAction(action, patch)} />


### PR DESCRIPTION
The JIRA ticket for this issue is [EAB-691](https://support.cop.homeoffice.gov.uk/browse/EAB-691).

This is the same issue that was solved for regular components in [CI-130](https://support.cop.homeoffice.gov.uk/browse/CI-130). The previous fix didn't account for nested components.

The `formData` passed to a component is now merged with a component's `patch` data. This will replace any missing nested values if they are present in `patch`.
