### PR TITLE
EAB-628 Added support for pre-populating date inputs with today's date

### DIFF
--- a/src/utils/Component/getComponent.js
+++ b/src/utils/Component/getComponent.js
@@ -16,6 +16,7 @@ import {
   WarningText
 } from '@ukhomeoffice/cop-react-components';
 import React from 'react';
+import dayjs from 'dayjs';
 
 // Local imports
 import { ComponentTypes } from '../../models';
@@ -49,6 +50,9 @@ const getCheckboxes = (config) => {
 
 const getDate = (config) => {
   const attrs = cleanAttributes(config);
+  if (attrs.defaultValue === 'today') {
+    attrs.defaultValue = dayjs().format('DD-MM-YYYY');
+  }
   return <DateInput {...attrs} />;
 };
 


### PR DESCRIPTION
### Description
Added support for a default value to be supplied in a Form Renderer JSON file for any DateInput component. Any date string in the format `DD-MM-YYYY` is supported. Using the word `today` instead of a date string will cause Form Renderer to supply today's date, in the form `DD-MM-YYYY`, as the default value.

### To test
To test this functionality, define a date component in the Form Renderer sandbox and add the field:
```
...
"defaultValue": "01-01-2022",
...
```
or
```
...
"defaultValue": "today",
...
```