### PR TITLE
Added support for "contains" operator on conditional display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/cop-react-form-renderer",
-  "version": "3.7.0",
+  "version": "3.9.0",
   "private": false,
   "scripts": {
     "clean": "rimraf dist",

--- a/src/docs/ConditionalDisplayExamples.stories.mdx
+++ b/src/docs/ConditionalDisplayExamples.stories.mdx
@@ -173,7 +173,7 @@ In the above example, the `BMWModel` component **will** be shown when the value
 of the `cars` field **contains** `BMW`.
 
 In this scenario, the component will be shown if the `cars` field is one of the following: <br/>
-An array containing `BMW` e.g. `"cars": "['Ford', 'Mercedes', 'BMW', 'Lexus']"` <br/>
+An array containing `BMW` e.g. `"cars": ['Ford', 'Mercedes', 'BMW', 'Lexus']` <br/>
 A string containing `BMW` e.g. `"cars": "Ford,Mercedes,BMW,LEXUS"` <br/>
 Note: `contains` also works for integer arrays
 

--- a/src/docs/ConditionalDisplayExamples.stories.mdx
+++ b/src/docs/ConditionalDisplayExamples.stories.mdx
@@ -154,3 +154,28 @@ if the value of `areYouACivilServant` is "yes", `delegateEmails` will still be s
 ### When to use type `or`
 
 Use type `or` when you want a component, page or container to be shown if **at least one** of the conditions you provide are true.
+
+## Contains
+
+```json
+{
+  "id": "BMWModel",
+  /* ... */
+  "show_when": {
+    "field": "cars",
+    "op": "contains",
+    "values": "BMW"
+  }
+}
+```
+
+In the above example, the `BMWModel` component **will** be shown when the value
+of the `cars` field **contains** `BMW`.
+
+In this scenario, the component will be shown if the `cars` field is one of the following: <br/>
+An array containing `BMW` e.g. `"cars": "['Ford', 'Mercedes', 'BMW', 'Lexus']"` <br/>
+A string containing `BMW` e.g. `"cars": "Ford,Mercedes,BMW,LEXUS"` <br/>
+Note: `contains` also works for integer arrays
+
+### When to use a `contains` operator
+Use the `contains` operator when you want to show a component on the condition that a field contains a given value. 

--- a/src/utils/Condition/meetsCondition.js
+++ b/src/utils/Condition/meetsCondition.js
@@ -46,7 +46,11 @@ const meetsCondition = (condition, value) => {
         return true;
       }
       case 'contains': {
-        return value.toString().includes(compare);
+        if (value){
+          return value.toString().includes(compare);
+        }
+       // If no value is provided, the field cannot contain it, so it must fail the condition.
+       return false; 
       }
       default:
         return false;

--- a/src/utils/Condition/meetsCondition.js
+++ b/src/utils/Condition/meetsCondition.js
@@ -46,11 +46,8 @@ const meetsCondition = (condition, value) => {
         return true;
       }
       case 'contains': {
-        if (value){
-          return value.toString().includes(compare);
-        }
+        return value?.toString().toLowerCase().includes(compare);
        // If no value is provided, the field cannot contain it, so it must fail the condition.
-       return false; 
       }
       default:
         return false;

--- a/src/utils/Condition/meetsCondition.js
+++ b/src/utils/Condition/meetsCondition.js
@@ -45,6 +45,9 @@ const meetsCondition = (condition, value) => {
         // If it's not an array, nothing can be IN it, so it must meet the condition.
         return true;
       }
+      case 'contains': {
+        return value.toString().includes(compare);
+      }
       default:
         return false;
     }

--- a/src/utils/Condition/meetsCondition.test.js
+++ b/src/utils/Condition/meetsCondition.test.js
@@ -329,6 +329,30 @@ describe('utils.Condition.meetsCondition', () => {
       const CONDITION = getCondition(op, VALUE)
       expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
     });
+    it('should reject any field when the value is null', () => {
+      const FIELD = ['alpha','bravo','charlie'];
+      const VALUE = null;
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject any field when the value is undefined', () => {
+      const FIELD = ['alpha','bravo','charlie'];
+      const VALUE = undefined;
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject any value when the field is undefined', () => {
+      const FIELD = null;
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject any value when the field is undefined', () => {
+      const FIELD = undefined;
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
 
   });
 

--- a/src/utils/Condition/meetsCondition.test.js
+++ b/src/utils/Condition/meetsCondition.test.js
@@ -269,6 +269,69 @@ describe('utils.Condition.meetsCondition', () => {
 
   });
 
+  describe('operator contains', () => {
+    const op = 'contains';
+    
+    // Should match...
+    it('should match a string that is in the field array', () => {
+      const FIELD = ['alpha','bravo','charlie'];
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeTruthy();
+    });
+    it('should match a sub-string that is in the field array', () => {
+      const FIELD = ['alpha','bravo','charlie'];
+      const VALUE = 'alp';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeTruthy();
+    });
+    it('should match a number that is in the field array', () => {
+      const FIELD = [1,2,3];
+      const VALUE = 1;
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeTruthy();
+    });
+    it('should match a sub-string that is in the field string', () => {
+      const FIELD = 'alphabravocharlie';
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeTruthy();
+    });
+
+    // Should reject...
+    it('should reject a string that is missing from the field array', () => {
+      const FIELD = ['alpha','bravo','charlie'];
+      const VALUE = 'delta';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject a number that is missing from the field array', () => {
+      const FIELD = [1,2,3];
+      const VALUE = 4;
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject a substring that is missing from the field string', () => {
+      const FIELD = 'alphabravocharlie';
+      const VALUE = 'delta';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject any value when the field is an empty Array', () => {
+      const FIELD = [];
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+    it('should reject any value when the field is an empty string', () => {
+      const FIELD = '';
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
+    });
+
+  });
+
   describe('unknown operator', () => {
     const op = 'definitely_not_a_real_operator';
 

--- a/src/utils/Condition/meetsCondition.test.js
+++ b/src/utils/Condition/meetsCondition.test.js
@@ -297,6 +297,12 @@ describe('utils.Condition.meetsCondition', () => {
       const CONDITION = getCondition(op, VALUE)
       expect(meetsCondition(CONDITION, FIELD)).toBeTruthy();
     });
+    it('should match a string that is in the field array regardless of case', () => {
+      const FIELD = ['Alpha','bravo','charlie'];
+      const VALUE = 'alpha';
+      const CONDITION = getCondition(op, VALUE)
+      expect(meetsCondition(CONDITION, FIELD)).toBeTruthy();
+    });
 
     // Should reject...
     it('should reject a string that is missing from the field array', () => {
@@ -341,7 +347,7 @@ describe('utils.Condition.meetsCondition', () => {
       const CONDITION = getCondition(op, VALUE)
       expect(meetsCondition(CONDITION, FIELD)).toBeFalsy();
     });
-    it('should reject any value when the field is undefined', () => {
+    it('should reject any value when the field is null', () => {
       const FIELD = null;
       const VALUE = 'alpha';
       const CONDITION = getCondition(op, VALUE)


### PR DESCRIPTION
### Description
show_when can now be passed on a component or page with the `contains` operator. This is different to the `in` operator in that the in operator is used to pass an array of accepted values that a given field is "in", whereas `contains` is used to pass a single accepted value which is "in" a field.


### To test
Covered by accompanying unit tests. Functionality can be tested in the Form Renderer Sandbox by adding a component with a show_when with "op": "contains".
1. Add an array field to the `initial data` tab in form renderer sandbox. e.g. "something" : ["alpha", "bravo", "charlie" ]
2. use the below component and confirm that it is displayed
```
    {
      "id": "status",
      "fieldId": "status",
      "type": "text",
      "label": "select status",
      "required": true,
      "show_when": [
        {
          "field": "something",
          "op": "contains",
          "value": "alpha"
        }
      ]
    }
```
3. change the component check for a value not in the array and confirm that it is no longer displayed
```
    {
      "id": "status",
      "fieldId": "status",
      "type": "text",
      "label": "select status",
      "required": true,
      "show_when": [
        {
          "field": "something",
          "op": "contains",
          "value": "delta"
        }
      ]
    }
```