### PR TITLE
Update cop-react-components to version 1.10.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.9.5",
+    "@ukhomeoffice/cop-react-components": "1.10.0",
     "axios": "^0.23.0",
     "dayjs": "^1.11.0",
     "govuk-frontend": "^3.13.0",


### PR DESCRIPTION
Following merge of https://github.com/UKHomeOffice/cop-react-components/pull/108