### PR TITLE
Update cop-react-components to version 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "post-compile": "rimraf dist/*.test.* dist/**/*.test.* dist/**/*.stories.* dist/docs dist/assets"
   },
   "dependencies": {
-    "@ukhomeoffice/cop-react-components": "1.9.5",
+    "@ukhomeoffice/cop-react-components": "1.10.0",
     "axios": "^0.23.0",
     "dayjs": "^1.11.0",
     "govuk-frontend": "^3.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4336,10 +4336,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ukhomeoffice/cop-react-components@1.9.5":
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.9.5.tgz#e71bc0c0eb7bd894a02f756971bb4d68f8412c12"
-  integrity sha512-CH8M49J07s9+3R3FZjsPWmpePzxF40wiBj9Vg+ugXZkVP8OsGwjPHM502mCDxEoZlpfj3VLw8u0mxcVqn0xDeg==
+"@ukhomeoffice/cop-react-components@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@ukhomeoffice/cop-react-components/-/cop-react-components-1.10.0.tgz#65b0a195723c5b87b7f2cf80ca36d3f336a58c50"
+  integrity sha512-wQDZDA/TDRgTE4w9otIvIUqP0ZybHI7OAjHMhiZ99/p4fj3ktoLfTULj1GC0th1gpChZKg1aWg+q8szsSrEWEQ==
   dependencies:
     accessible-autocomplete "2.0.3"
     govuk-frontend "^3.13.0"


### PR DESCRIPTION
Following merge of https://github.com/UKHomeOffice/cop-react-components/pull/108